### PR TITLE
GTK settings integrations

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -272,6 +272,10 @@ pub async fn watch_theme(
                             eprintln!("Error updating the theme toolkit config {err:?}");
                         }
 
+                        if changes.contains(&"icon_theme") {
+                            set_gnome_icon_theme(tk.icon_theme.clone());
+                        }
+
                         if changes.contains(&"show_maximize") || changes.contains(&"show_minimize") {
                             set_gnome_button_layout(tk.show_maximize, tk.show_minimize);
                         }
@@ -474,4 +478,18 @@ fn set_gnome_desktop_interface(is_dark: bool) {
                 .await;
         });
     }
+}
+
+fn set_gnome_icon_theme(theme: String) {
+    tokio::spawn(async move {
+        let _res = tokio::process::Command::new("gsettings")
+            .args(&[
+                "set",
+                "org.gnome.desktop.interface",
+                "icon-theme",
+                theme.as_str(),
+            ])
+            .status()
+            .await;
+    });
 }


### PR DESCRIPTION
- Use `gsettings` to apply COSMIC theme changes to GTK3/4 applications
    - On theme mode changes when the apply-global-theme is set
        - Set gtk-theme to adw-gtk3/adw-gtk3-dark if it is installed
        - Set color-scheme to `prefer-light`/`prefer-dark`
            - Requires application restart to see changes
    - On button layout changes in CosmicTk, change button-layout for GNOME
    - On icon theme changes in CosmicTk, change icon-theme for GNOME

Closes #16 