### PR TITLE
fix: update libcosmic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "clipboard_macos"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-dnd-6#8a816d8f218e290041bb5ef6d3b695c38e0a53b7"
+source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-dnd-7#a5be70405574e98c292537fd3b01a1352550b9bf"
 dependencies = [
  "objc",
  "objc-foundation",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "clipboard_wayland"
 version = "0.2.2"
-source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-dnd-6#8a816d8f218e290041bb5ef6d3b695c38e0a53b7"
+source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-dnd-7#a5be70405574e98c292537fd3b01a1352550b9bf"
 dependencies = [
  "dnd",
  "mime",
@@ -754,7 +754,7 @@ dependencies = [
 [[package]]
 name = "clipboard_x11"
 version = "0.4.2"
-source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-dnd-6#8a816d8f218e290041bb5ef6d3b695c38e0a53b7"
+source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-dnd-7#a5be70405574e98c292537fd3b01a1352550b9bf"
 dependencies = [
  "thiserror",
  "x11rb",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -967,13 +967,13 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.11.2"
-source = "git+https://github.com/pop-os/cosmic-text.git#2f5f2c63dabc0173adaa95d619a777454a3c39af"
+source = "git+https://github.com/pop-os/cosmic-text.git#8bb45d7aca5b4a109924f3162d670297b6bd4a19"
 dependencies = [
  "bitflags 2.5.0",
  "fontdb",
- "libm",
  "log",
  "rangemap",
+ "rayon",
  "rustc-hash",
  "rustybuzz",
  "self_cell",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1255,7 +1255,7 @@ dependencies = [
 [[package]]
 name = "dnd"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-dnd-6#8a816d8f218e290041bb5ef6d3b695c38e0a53b7"
+source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-dnd-7#a5be70405574e98c292537fd3b01a1352550b9bf"
 dependencies = [
  "bitflags 2.5.0",
  "mime",
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "dnd",
  "iced_core",
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2072,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "bitflags 2.5.0",
  "dnd",
@@ -2094,7 +2094,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "futures",
  "iced_core",
@@ -2106,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "bitflags 2.5.0",
  "bytemuck",
@@ -2130,7 +2130,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "iced_sctk"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "enum-repr",
  "float-cmp",
@@ -2182,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -2192,7 +2192,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2209,7 +2209,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "bitflags 2.5.0",
  "bytemuck",
@@ -2235,7 +2235,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -2462,7 +2462,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#9f017de1fab4bb16606c6ae428bf6df2395e4c8b"
+source = "git+https://github.com/pop-os/libcosmic#80b7049584c1c4864d85b4127eed15ec2dc3c45a"
 dependencies = [
  "apply",
  "chrono",
@@ -2483,6 +2483,7 @@ dependencies = [
  "iced_widget",
  "lazy_static",
  "palette",
+ "serde",
  "slotmap",
  "taffy",
  "thiserror",
@@ -2746,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "mime"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-dnd-6#8a816d8f218e290041bb5ef6d3b695c38e0a53b7"
+source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-dnd-7#a5be70405574e98c292537fd3b01a1352550b9bf"
 dependencies = [
  "smithay-clipboard",
 ]
@@ -3775,8 +3776,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.0"
-source = "git+https://github.com/smithay/client-toolkit?rev=3bed072#3bed072b966022f5f929d12f3aff089b1ace980b"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "837d3067369e24aeda699a5d9fc5aa14ca14a84dd70aeed7156bfa04a5605b32"
 dependencies = [
  "bitflags 2.5.0",
  "bytemuck",
@@ -3803,7 +3805,7 @@ dependencies = [
 [[package]]
 name = "smithay-clipboard"
 version = "0.8.0"
-source = "git+https://github.com/pop-os/smithay-clipboard?tag=pop-dnd-4#ab422ddcc95a9a1717df094f9c8fe69e2fdb2a27"
+source = "git+https://github.com/pop-os/smithay-clipboard?tag=pop-dnd-5#d099e82a4c1e7d3e88dc34b7333de21928b1b22c"
 dependencies = [
  "libc",
  "raw-window-handle",
@@ -4540,9 +4542,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d50fa61ce90d76474c87f5fc002828d81b32677340112b4ef08079a9d459a40"
+checksum = "34e9e6b6d4a2bb4e7e69433e0b35c7923b95d4dc8503a84d25ec917a4bbfdf07"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -4554,9 +4556,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f"
+checksum = "1e63801c85358a431f986cffa74ba9599ff571fc5774ac113ed3b490c19a1133"
 dependencies = [
  "bitflags 2.5.0",
  "rustix 0.38.34",
@@ -4588,9 +4590,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+checksum = "83d0f1056570486e26a3773ec633885124d79ae03827de05ba6c85f79904026c"
 dependencies = [
  "bitflags 2.5.0",
  "wayland-backend",
@@ -4600,9 +4602,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+checksum = "a7dab47671043d9f5397035975fe1cac639e5bca5cc0b3c32d09f01612e34d24"
 dependencies = [
  "bitflags 2.5.0",
  "wayland-backend",
@@ -4613,9 +4615,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283"
+checksum = "67da50b9f80159dec0ea4c11c13e24ef9e7574bd6ce24b01860a175010cea565"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -4624,9 +4626,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
+checksum = "105b1842da6554f91526c14a2a2172897b7f745a805d62af4ce698706be79c12"
 dependencies = [
  "dlib",
  "log",
@@ -4802,7 +4804,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "window_clipboard"
 version = "0.4.1"
-source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-dnd-6#8a816d8f218e290041bb5ef6d3b695c38e0a53b7"
+source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-dnd-7#a5be70405574e98c292537fd3b01a1352550b9bf"
 dependencies = [
  "clipboard-win",
  "clipboard_macos",

--- a/src/main.rs
+++ b/src/main.rs
@@ -506,7 +506,7 @@ async fn main() -> zbus::Result<()> {
                                 {
                                     eprintln!("Failed to send theme mode update {err:?}");
                                 }
-                            } else if id.as_str() == cosmic::config::toolkit::ID {
+                            } else if id.as_str() == cosmic::config::ID {
                                 if let Err(err) =
                                     theme_tx.send(theme::ThemeMsg::Tk(key.clone())).await
                                 {


### PR DESCRIPTION
avoids settings gtk window controls when exporting the theme