### PR TITLE
Expose brightness as percent in BrightnessDevice

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -250,8 +250,8 @@ async fn choose_best_backlight(
         if let Some(sysname) = device.sysname().to_str() {
             match BrightnessDevice::new("backlight", sysname.to_owned()).await {
                 Ok(brightness_device) => {
-                    if brightness_device.max_brightness() > best_max_brightness {
-                        best_max_brightness = brightness_device.max_brightness();
+                    if brightness_device.max_absolute_brightness() > best_max_brightness {
+                        best_max_brightness = brightness_device.max_absolute_brightness();
                         best_backlight = Some(brightness_device);
                     }
                 }


### PR DESCRIPTION
Currently `BrightnessDevice` operates with the raw values from `sysfs` and exposes them to other components via zbus. This can lead to some unexpected behaviour (e.g. when read from `cosmic-osd`), since the brightness values are not normalised by the maximum brightness there. This was reported in an issue here: https://github.com/pop-os/cosmic-applets/issues/484

This PR modifies `BrightnessDevice` so that it exposes brightness in percent to the outside, so any caller does not have to take into account the maximum brightness and normalise the value themselves.