### PR TITLE
Add `MaxDisplayBrightness` property

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,15 @@ impl SettingsDaemon {
     }
 
     #[zbus(property)]
+    async fn max_display_brightness(&self) -> i32 {
+        if let Some(brightness_device) = self.display_brightness_device.as_ref() {
+            brightness_device.max_brightness() as i32
+        } else {
+            -1
+        }
+    }
+
+    #[zbus(property)]
     async fn set_display_brightness(&self, value: i32) {
         if let Some(logind_session) = self.logind_session.as_ref() {
             if let Some(brightness_device) = self.display_brightness_device.as_ref() {


### PR DESCRIPTION
This seems like the best way to expose the brightness and max brightness for now.

In the future we may want to expose multiple brightness devices (https://github.com/pop-os/cosmic-applets/issues/428). It would also be possible for client to not require the daemon and use sysfs and udev/netlink directly, but if we use DDC for external monitors we'll need to handle that a daemon as well.