### PR TITLE
feat: Add locale1 synchronization support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmic-comp-config"
+version = "0.1.0"
+source = "git+https://github.com/pop-os/cosmic-comp#2d0f1cbf2be311b91096b2f2332cd7bafabbfde3"
+dependencies = [
+ "cosmic-config",
+ "input",
+ "serde",
+]
+
+[[package]]
 name = "cosmic-config"
 version = "0.1.0"
 source = "git+https://github.com/pop-os/libcosmic#bd84f1f07ddf531fb11df4f897a9ec7cce229fe5"
@@ -967,11 +977,13 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "cosmic-comp-config",
  "cosmic-config",
  "cosmic-theme",
  "dirs",
  "geoclue2",
  "libcosmic",
+ "locale1",
  "memoize",
  "notify",
  "notify-rust",
@@ -1782,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "geoclue2"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#1fdfcc8045e6732fc54b2c945008e89999a6cf71"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#cd21ddcb1b5cbfc80ab84b34d3c8b1ff3d81179a"
 dependencies = [
  "serde",
  "serde_repr",
@@ -2343,6 +2355,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "input"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7911ce3db9c10c5ab4a35c49af778a5f9a827bd0f7371d9be56175d8dd2740d0"
+dependencies = [
+ "bitflags 2.5.0",
+ "input-sys",
+ "io-lifetimes",
+ "libc",
+ "log",
+ "udev",
+]
+
+[[package]]
+name = "input-sys"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd4f5b4d1c00331c5245163aacfe5f20be75b564c7112d45893d4ae038119eb0"
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,6 +2611,14 @@ name = "linux-raw-sys"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b5399f6804fbab912acbd8878ed3532d506b7c951b8f9f164ef90fef39e3f4"
+
+[[package]]
+name = "locale1"
+version = "0.1.0"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#cd21ddcb1b5cbfc80ab84b34d3c8b1ff3d81179a"
+dependencies = [
+ "zbus 4.3.0",
+]
 
 [[package]]
 name = "lock_api"
@@ -4456,7 +4496,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "upower_dbus"
 version = "0.3.2"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#1fdfcc8045e6732fc54b2c945008e89999a6cf71"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#cd21ddcb1b5cbfc80ab84b34d3c8b1ff3d81179a"
 dependencies = [
  "serde",
  "serde_repr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,13 @@ geoclue2 = { git = "https://github.com/pop-os/dbus-settings-bindings" }
 cosmic-theme = { git = "https://github.com/pop-os/libcosmic", features = [
     "export",
 ] }
+cosmic-comp-config = { git = "https://github.com/pop-os/cosmic-comp" }
 cosmic-config = { git = "https://github.com/pop-os/libcosmic" }
 chrono = "0.4.35"
 libcosmic = { git = "https://github.com/pop-os/libcosmic" }
 acpid_plug = "0.1.2"
 upower_dbus = { git = "https://github.com/pop-os/dbus-settings-bindings" }
+locale1 = { git = "https://github.com/pop-os/dbus-settings-bindings" }
 notify-rust = "4.9.0"
 walkdir = "2.5.0"
 memoize = "0.4.2"

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ endif
 
 BIN = cosmic-settings-daemon
 SYSTEM_ACTIONS_CONF = "$(DESTDIR)$(sharedir)/cosmic/com.system76.CosmicSettings.Shortcuts/v1/system_actions"
+POLKIT_RULE = "$(DESTDIR)$(sharedir)/polkit-1/rules.d/cosmic-settings-daemon.rules"
 
 all: $(BIN)
 
@@ -34,6 +35,7 @@ $(BIN): Cargo.toml Cargo.lock src/main.rs vendor-check
 install:
 	install -Dm0755 "target/$(TARGET)/$(BIN)" "$(DESTDIR)$(bindir)/$(BIN)"
 	install -Dm0644 "data/system_actions.ron" "$(SYSTEM_ACTIONS_CONF)"
+	install -Dm0644 "data/polkit-1/rules.d/cosmic-settings-daemon.rules" "$(POLKIT_RULE)"
 
 ## Cargo Vendoring
 

--- a/data/polkit-1/rules.d/cosmic-settings-daemon.rules
+++ b/data/polkit-1/rules.d/cosmic-settings-daemon.rules
@@ -1,0 +1,8 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.locale1.set-keyboard" &&
+        subject.local &&
+        subject.active &&
+        subject.isInGroup ("sudo")) {
+            return polkit.Result.YES;
+        }
+});

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -1,0 +1,80 @@
+use anyhow::Context;
+use cosmic_comp_config::XkbConfig;
+use cosmic_config::{ConfigGet, ConfigSet};
+use tokio::sync::mpsc::Receiver;
+use tokio_stream::StreamExt;
+
+pub const COSMIC_COMP_ID: &'static str = "com.system76.CosmicComp";
+pub const COSMIC_COMP_XDG_KEY: &'static str = "xkb_config";
+
+pub async fn sync_locale1(mut rx: Receiver<()>) -> anyhow::Result<()> {
+    let conn = zbus::Connection::system().await?;
+    let proxy = locale1::locale1Proxy::new(&conn).await?;
+    let config = cosmic_config::Config::new(COSMIC_COMP_ID, 1)
+        .context("Found no cosmic-comp configuration")?;
+
+    sync_locale1_to_cosmic(&config, &proxy)
+        .await
+        .context("Failed to read initial locale1 xkb configuration")?;
+
+    let mut model_stream = proxy.receive_x11model_changed().await;
+    let mut layout_stream = proxy.receive_x11layout_changed().await;
+    let mut variant_stream = proxy.receive_x11variant_changed().await;
+    let mut options_stream = proxy.receive_x11options_changed().await;
+
+    loop {
+        if let Err(err) = tokio::select! {
+            _ = rx.recv() => sync_cosmic_to_locale1(&config, &proxy).await,
+            _ = model_stream.next() => sync_locale1_to_cosmic(&config, &proxy).await,
+            _ = layout_stream.next() => sync_locale1_to_cosmic(&config, &proxy).await,
+            _ = variant_stream.next() => sync_locale1_to_cosmic(&config, &proxy).await,
+            _ = options_stream.next() => sync_locale1_to_cosmic(&config, &proxy).await,
+        } {
+            eprintln!("Failed to sync xkb_config with systemd-localed: {}", err);
+        };
+    }
+}
+
+async fn sync_cosmic_to_locale1(
+    config: &cosmic_config::Config,
+    proxy: &locale1::locale1Proxy<'_>,
+) -> anyhow::Result<()> {
+    let xkb_config = config
+        .get::<XkbConfig>(COSMIC_COMP_XDG_KEY)
+        .unwrap_or_default();
+    proxy
+        .set_x11keyboard(
+            &xkb_config.layout,
+            &xkb_config.model,
+            &xkb_config.variant,
+            xkb_config.options.as_deref().unwrap_or(""),
+            true,
+            false,
+        )
+        .await
+        .context("Failed to update systemd-locale1 from xkb_config")?;
+    Ok(())
+}
+
+async fn sync_locale1_to_cosmic(
+    config: &cosmic_config::Config,
+    proxy: &locale1::locale1Proxy<'_>,
+) -> anyhow::Result<()> {
+    let current_config = config
+        .get::<XkbConfig>(COSMIC_COMP_XDG_KEY)
+        .unwrap_or_default();
+    let initial_config = XkbConfig {
+        model: proxy.x11model().await?,
+        layout: proxy.x11layout().await?,
+        variant: proxy.x11variant().await?,
+        options: match proxy.x11options().await?.as_str() {
+            "" => None,
+            x => Some(x.to_string()),
+        },
+        ..current_config
+    };
+    config
+        .set::<XkbConfig>(COSMIC_COMP_XDG_KEY, initial_config)
+        .context("Failed to update xkb_config from systemd-localed")?;
+    Ok(())
+}


### PR DESCRIPTION
This enabled syncing keyboard settings via the `org.freedesktop.locale1` interface usually provided by `systemd-localed`. This is useful to allow login managers to override layouts and carry those settings into the session and vise versa. Additionally this gives a programmatic and well-known interface to change cosmic-comps keyboard settings useful e.g. to distro installers and other distribution specfic configuration.

Fixes https://github.com/pop-os/cosmic-comp/issues/458