### PR TITLE
debian: Add missing libinput dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends:
   debhelper-compat (= 11),
   cargo,
   libudev-dev,
+  libinput-dev,
   pkg-config,
 Standards-Version: 4.3.0
 Homepage: https://github.com/pop-os/cosmic-settings-daemon


### PR DESCRIPTION
Didn't catch in #35 that cosmic-comp-config pulls in libinput. This fixes the debian package build.