### PR TITLE
fix: gnome button layout differs from COSMIC on first login

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -157,6 +157,8 @@ pub async fn watch_theme(
         }
     };
 
+    set_gnome_button_layout(tk.show_maximize, tk.show_minimize);
+
     let light_helper = CosmicTheme::light_config()?;
     let dark_helper = CosmicTheme::dark_config()?;
 


### PR DESCRIPTION
Sets the button layout on startup, rather than only when the toolkit config is changed.