### PR TITLE
fix: do not exit on Geoclue failure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -342,8 +342,14 @@ pub enum Change {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> zbus::Result<()> {
-    std::process::Command::new(GEOCLUE_AGENT.unwrap_or("/usr/libexec/geoclue-2.0/demos/agent"))
-        .spawn()?;
+    // Try to start Geoclue agent
+    if let Err(err) =
+        std::process::Command::new(GEOCLUE_AGENT.unwrap_or("/usr/libexec/geoclue-2.0/demos/agent"))
+            .spawn()
+    {
+        eprintln!("Failed to start Geoclue agent: {err}");
+    }
+
     task::LocalSet::new()
         .run_until(async {
             let backlights = match backlight_enumerate() {


### PR DESCRIPTION
Hi !

This fixes #45, which was caused by a difference in paths to the Geoclue agent on some other distros. I also made it so the failure to launch Geoclue doesn't terminate the settings daemon.

Thanks !