### PR TITLE
config: Add `Suspend` system action

### DIFF
--- a/config/src/shortcuts/action.rs
+++ b/config/src/shortcuts/action.rs
@@ -163,6 +163,8 @@ pub enum System {
     PlayPrev,
     /// Takes a screenshot
     Screenshot,
+    /// Suspend the system
+    Suspend,
     /// Opens the system default terminal
     Terminal,
     /// Lowers the volume of the active audio output

--- a/data/system_actions.ron
+++ b/data/system_actions.ron
@@ -27,6 +27,8 @@
     PlayPrev: "playerctl previous",
     /// Takes a screenshot
     Screenshot: "cosmic-screenshot",
+    /// Suspend the system
+    Suspend: "systemctl suspend",
     /// Opens the system default terminal
     Terminal: "cosmic-term",
     /// Lowers the volume of the active output device


### PR DESCRIPTION
Cosmic-idle needs to suspend the system. It would make sense if it used a `system_action` so the command is configurable (on non-systemd, BSD), and is also available as a key binding.

Adding this to `system_actions.ron` though breaks cosmic-comp keybindings, since adding an `enum` variant makes it fail to parse the file... we should change how that works so it doesn't break other bindings and can just ignore it, but serde doesn't seem to have a good way to do that. (Custom deserialize implementation for a `SystemActions` type? Not very convenient, but should be possible...)