### PR TITLE
Change default terminal to x-terminal-emulator

### DIFF
--- a/data/system_actions.ron
+++ b/data/system_actions.ron
@@ -30,7 +30,7 @@
     /// Takes a screenshot
     Screenshot: "cosmic-screenshot",
     /// Opens the system default terminal
-    Terminal: "cosmic-term",
+    Terminal: "x-terminal-emulator",
     /// Lowers the volume of the active output device
     VolumeLower: "amixer sset Master on; amixer sset Master 5%-",
     /// Raises the volume of the active output device


### PR DESCRIPTION
Change default terminal for Super-T from `cosmic-term` to `x-terminal-emulator`

Which lets you change it via `update-alternatives`

- There isn't a UI to change this right now
- You can add `~/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1/system_actions` with an override ... but
    - It doesn't apply on login, it only works when you edit the file

This doesn't cause a functional difference by default - because `x-terminal-emulator` is configured to be `cosmic-term`.