### PR TITLE
config: Added VimSymbols to allow for configuring impliedDirections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ endif
 
 BIN = cosmic-settings-daemon
 SYSTEM_ACTIONS_CONF = "$(DESTDIR)$(sharedir)/cosmic/com.system76.CosmicSettings.Shortcuts/v1/system_actions"
+VIM_SYMBOLS_CONF = "$(DESTDIR)$(sharedir)/cosmic/com.system76.CosmicSettings.Shortcuts/v1/vim_symbols"
 POLKIT_RULE = "$(DESTDIR)$(sharedir)/polkit-1/rules.d/cosmic-settings-daemon.rules"
 
 all: $(BIN)
@@ -36,6 +37,7 @@ $(BIN): Cargo.toml Cargo.lock src/main.rs vendor-check
 install:
 	install -Dm0755 "$(CARGO_TARGET_DIR)/$(TARGET)/$(BIN)" "$(DESTDIR)$(bindir)/$(BIN)"
 	install -Dm0644 "data/system_actions.ron" "$(SYSTEM_ACTIONS_CONF)"
+	install -Dm0644 "data/vim_symbols.ron" "$(VIM_SYMBOLS_CONF)"
 	install -Dm0644 "data/polkit-1/rules.d/cosmic-settings-daemon.rules" "$(POLKIT_RULE)"
 
 ## Cargo Vendoring

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
 pub mod shortcuts;
-pub use shortcuts::{Action, Binding, Shortcuts};
+pub use shortcuts::{Action, Binding, Shortcuts, VimSymbols};
 pub mod window_rules;

--- a/config/src/shortcuts/binding.rs
+++ b/config/src/shortcuts/binding.rs
@@ -66,10 +66,10 @@ impl Binding {
     /// Get the inferred direction of a xkb key
     pub fn inferred_direction(&self) -> Option<Direction> {
         match self.key? {
-            xkb::Keysym::Left | xkb::Keysym::h | xkb::Keysym::H => Some(Direction::Left),
-            xkb::Keysym::Down | xkb::Keysym::j | xkb::Keysym::J => Some(Direction::Down),
-            xkb::Keysym::Up | xkb::Keysym::k | xkb::Keysym::K => Some(Direction::Up),
-            xkb::Keysym::Right | xkb::Keysym::l | xkb::Keysym::L => Some(Direction::Right),
+            xkb::Keysym::Left => Some(Direction::Left),
+            xkb::Keysym::Down => Some(Direction::Down),
+            xkb::Keysym::Up => Some(Direction::Up),
+            xkb::Keysym::Right => Some(Direction::Right),
             _ => None,
         }
     }

--- a/data/vim_symbols.ron
+++ b/data/vim_symbols.ron
@@ -1,0 +1,6 @@
+{
+  "h": Left,
+  "j": Down,
+  "k": Up,
+  "l": Right,
+}


### PR DESCRIPTION
Since I use a different keymap, I would like the ability to change the shortcuts involving the vim keybindings.

I thought I could change most of them, but was not allowed to use `Super+Ctrl+H` for next workspace when in vertical workspace mode because that would typically be left in vim.  Is this a feature that would be considered in the Cosmic Desktop environment? I am willing to implement this feature in `cosmic-comp` as well (I already have a [proof of concept](https://github.com/sefodopo/cosmic-comp/tree/keymap) that appears to be working on my system (NixOS 24.11) using my fork of [`nixos-cosmic`](https://github.com/sefodopo/nixos-cosmic/tree/keymap)).

## Questions about implementation
- VimSymbols probably isn't the best name, what should we use?
- How to get the config in `Binding.inferred_direction()`, ideas:
    - Should a VimSymbols parameter be added
    - Move the inferred_direction to the VimSymbols and take in the key or pattern
    - Have both functions somehow
    - Leave it alone and never touch it again
- Where should this structure and implementation get put?
- What did I do wrong, or what should I change?