### PR TITLE
fix(tokio::async): Fix async call stylistic invocation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -480,12 +480,8 @@ async fn main() -> zbus::Result<()> {
                 .build()
                 .await?;
 
-            let conn_clone = connection.clone();
-            task::spawn_local(async move {
-                backlight_monitor_task(backlights, conn_clone).await;
-            });
-
-            tokio::task::spawn_local(battery::monitor());
+            task::spawn_local(backlight_monitor_task(backlights, connection.clone()));
+            task::spawn_local(battery::monitor());
 
             let conn_clone = connection.clone();
             let (ready_oneshot_tx, mut ready_oneshot_rx) = tokio::sync::oneshot::channel();
@@ -544,7 +540,7 @@ async fn main() -> zbus::Result<()> {
             });
 
             let conn_clone = connection.clone();
-            task::spawn(async move {
+            task::spawn_local(async move {
                 while let Some(changes) = rx.recv().await {
                     let Ok(settings_daemon) = conn_clone
                         .object_server()


### PR DESCRIPTION
I don't think this has any logical changes to the code, but having the code be stylistically similar makes it easier to read to lessen the cognitive load when reading it for the first time.

`spawn_local` vs `spawn` would be different if the Runtime was different(`#[tokio::main(flavor = "current_thread")]`) I believe, but maybe I misread the documentation?