### PR TITLE
fix: timezone-based theme auto-switching

### DIFF
--- a/src/location.rs
+++ b/src/location.rs
@@ -1,12 +1,12 @@
-use std::{collections::BTreeMap, io, path::Path, rc::Rc};
+use std::{collections::BTreeMap, io, path::Path, rc::Rc, time::Duration};
 
 use futures::{Stream, StreamExt};
 pub use geonames::GeoPosition;
-use notify::{RecursiveMode, Watcher};
-use tokio::task::JoinHandle;
+use notify::{PollWatcher, RecursiveMode, Watcher};
 
 static GEODATA: &'static [u8] = include_bytes!("../data/timezone-geodata.bitcode-v0-6");
 
+/// Decodes the embedded geodata containing the largest cities nearest each timezone.
 pub fn decode_geodata() -> BTreeMap<String, GeoPosition> {
     match geonames::bitcode::decode(GEODATA) {
         Ok(ok) => ok,
@@ -17,42 +17,89 @@ pub fn decode_geodata() -> BTreeMap<String, GeoPosition> {
     }
 }
 
-pub fn receive_timezones() -> (JoinHandle<()>, impl Stream<Item = io::Result<String>>) {
+/// Get a stream of timezone updates backed by a poll watcher.
+pub fn receive_timezones() -> (PollWatcher, impl Stream<Item = io::Result<String>>) {
     let (tx, rx) = tokio::sync::mpsc::channel(1);
 
-    let timezone_path: Rc<Path> = Rc::from(Path::new("/etc/timezone").canonicalize().unwrap());
+    let timezone_path: Rc<Path> = Rc::from(Path::new("/etc/localtime"));
 
-    let handle = tokio::task::spawn_local({
+    futures::executor::block_on(async {
+        _ = tx.send(()).await;
+    });
+
+    let event_handler = move |result: notify::Result<notify::Event>| {
+        if matches!(
+            result.map(|event| event.kind),
+            Ok(notify::EventKind::Modify(_))
+        ) {
+            futures::executor::block_on(async {
+                _ = tx.send(()).await;
+            })
+        }
+    };
+
+    // NOTE: Uses a poll watcher because inotify watchers automatically follow symlinks to files.
+    // We should switch back to an INotifyWatcher the moment the notify crate supports disabling symlink follows.
+    let mut watcher = notify::PollWatcher::new(
+        event_handler,
+        notify::Config::default()
+            .with_follow_symlinks(false) // NOTE: Does not currently do anything
+            .with_poll_interval(Duration::from_secs(1)),
+    )
+    .unwrap();
+
+    _ = watcher.watch(&timezone_path, RecursiveMode::NonRecursive);
+
+    let stream = tokio_stream::wrappers::ReceiverStream::new(rx).then(move |_| {
         let timezone_path = timezone_path.clone();
         async move {
-            let mut watcher =
-                notify::recommended_watcher(move |result: notify::Result<notify::Event>| {
-                    if matches!(
-                        result.map(|event| event.kind),
-                        Ok(notify::EventKind::Modify(notify::event::ModifyKind::Data(
-                            _
-                        )))
-                    ) {
-                        futures::executor::block_on(async {
-                            _ = tx.send(()).await;
-                        })
-                    }
-                })
-                .unwrap();
+            let mut zoneinfo_path = timezone_path.read_link()?;
 
-            _ = watcher.watch(&timezone_path, RecursiveMode::NonRecursive);
+            // The zoneinfo path may require resolving twice to get the correct geoname timezone.
+            if let Ok(path) = zoneinfo_path.read_link() {
+                zoneinfo_path = path;
+            }
 
-            futures::future::pending::<()>().await;
+            Ok(timezone_from_path(&zoneinfo_path))
         }
     });
 
-    let stream =
-        tokio_stream::wrappers::ReceiverStream::new(rx).then(move |_| {
-            let timezone_path = timezone_path.clone();
-            async move {
-                std::fs::read_to_string(&timezone_path).map(|contents| contents.trim().to_owned())
-            }
-        });
+    (watcher, stream)
+}
 
-    (handle, stream)
+/// Get timezone from a zoneinfo path
+fn timezone_from_path(path: &Path) -> String {
+    path.components()
+        .rev()
+        .take_while(|component| {
+            component.as_os_str() != "zoneinfo" && component.as_os_str() != ".."
+        })
+        .fold(String::new(), |buffer, component| {
+            let name = component.as_os_str().to_str().unwrap();
+            if buffer.is_empty() {
+                name.to_owned()
+            } else {
+                [name, "/", &buffer].concat()
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    #[test]
+    fn timezone_from_path() {
+        let mut path = Path::new("/usr/share/zoneinfo/America/Denver");
+        assert_eq!(
+            super::timezone_from_path(path),
+            String::from("America/Denver")
+        );
+
+        path = Path::new("../Pacific/Honolulu");
+        assert_eq!(
+            super::timezone_from_path(path),
+            String::from("Pacific/Honolulu")
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -488,13 +488,11 @@ async fn main() -> zbus::Result<()> {
             tokio::task::spawn_local(battery::monitor());
 
             let conn_clone = connection.clone();
-            let (ready_oneshot_tx, mut ready_oneshot_rx) = tokio::sync::oneshot::channel();
             task::spawn_local(async move {
                 if let Err(err) = watch_config_message_stream(
                     conn_clone,
                     watched_configs,
                     watched_states,
-                    ready_oneshot_tx,
                 )
                 .await
                 {
@@ -517,7 +515,6 @@ async fn main() -> zbus::Result<()> {
                 loop {
                     if let Err(err) = watch_theme(
                         &mut theme_rx,
-                        ready_oneshot_rx,
                         theme_cleanup_done_tx.clone(),
                         sigterm_rx.resubscribe(),
                     )
@@ -530,9 +527,6 @@ async fn main() -> zbus::Result<()> {
                     }
                     tokio::time::sleep(sleep).await;
                     sleep = sleep.saturating_mul(2);
-                    let new = tokio::sync::oneshot::channel();
-                    ready_oneshot_rx = new.1;
-                    _ = new.0.send(());
                 }
             });
 
@@ -650,9 +644,7 @@ async fn watch_config_message_stream(
     watched_states: Arc<
         RwLock<HashMap<(String, u64), (Connection, ObjectPath<'static>, WellKnownName<'static>)>>,
     >,
-    theme_oneshot_tx: tokio::sync::oneshot::Sender<()>,
 ) -> zbus::Result<()> {
-    let mut theme_oneshot_tx = Some(theme_oneshot_tx);
     let config_rule = MatchRule::builder()
         .msg_type(zbus::message::Type::MethodCall)
         .member("WatchConfig")?
@@ -723,11 +715,6 @@ async fn watch_config_message_stream(
             let Ok((id, version)) = msg.body().deserialize::<(String, u64)>() else {
                 continue;
             };
-            if id == cosmic_theme::THEME_MODE_ID {
-                if let Some(theme_oneshot_tx) = theme_oneshot_tx.take() {
-                    _ = theme_oneshot_tx.send(());
-                }
-            }
 
             let name_set = watched_config_names
                 .entry((id.clone(), version))


### PR DESCRIPTION
Tested by enabling theme auto-switch in COSMIC Settings, and then alternating timezones between Denver, Hawaii, Hong Kong, and Warsaw. Then killing the daemon and running it manually to observe if it applies the timezone-based theme on startup.

- Fixed theme watcher not running until the theme mode is modified
- Fixed initial timezone not being read on startup
- Fixed timezone being read from wrong path (`/etc/localtime` is updated by timedatectl)
- Fixed timezone not being updated due to inotify watcher following symlinks
- Fixed `US/Hawaii` by following the symlink twice
- Fixed auto-switch not applying a theme on daemon startup