### PR TITLE
fix(system_actions): Switch MuteMic to PipeWire

### DIFF
--- a/data/system_actions.ron
+++ b/data/system_actions.ron
@@ -22,7 +22,7 @@
     /// Mutes the active output device
     Mute: "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle",
     /// Mutes the active microphone
-    MuteMic: "amixer sset Capture toggle",
+    MuteMic: "wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle",
     /// Plays and Pauses audio
     PlayPause: "playerctl play-pause",
     /// Goes to the next track


### PR DESCRIPTION
Similarly to #72, this PR switches the MuteMic action to wpctl instead of amixer