### PR TITLE
config: Don't error if `tiling_exception_custom` is not present

### DIFF
--- a/config/src/window_rules/mod.rs
+++ b/config/src/window_rules/mod.rs
@@ -77,7 +77,15 @@ pub fn tiling_exceptions(context: &cosmic_config::Config) -> Vec<ApplicationExce
     let custom = context
         .get::<Vec<PreciseApplicationException>>("tiling_exception_custom")
         .unwrap_or_else(|why| {
-            tracing::error!("tiling exceptions custom config error: {why:?}");
+            if why.is_err() {
+                if let cosmic_config::Error::GetKey(_, err) = &why {
+                    if err.kind() != std::io::ErrorKind::NotFound {
+                        tracing::error!("tiling exceptions custom config error: {why}");
+                        return Vec::new();
+                    }
+                }
+            }
+            tracing::debug!("tiling exceptions custom config not present: {why}");
             Vec::new()
         });
 


### PR DESCRIPTION
As noted in https://github.com/pop-os/cosmic-comp/pull/1603, there's no need to a system default config file for this particular setting. So as an alternative to that PR, we can ensure this isn't printed as an error.

As noted in the description of https://github.com/pop-os/libcosmic/pull/948, if the system default is not present, `Error::GetKey` is returned, without mapping to the `Error::NotFound` variant. So check for that, as well as `.is_err()`.