### PR TITLE
chore: add optional keycode to Binding

### DIFF
--- a/config/src/shortcuts/binding.rs
+++ b/config/src/shortcuts/binding.rs
@@ -23,6 +23,8 @@ pub struct Binding {
         serialize_with = "super::sym::serialize"
     )]
     pub key: Option<xkb::Keysym>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keycode: Option<u32>,
     // A custom description for a custom binding
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -34,7 +36,18 @@ impl Binding {
         Binding {
             description: None,
             modifiers: modifiers.into(),
+            keycode: None,
             key,
+        }
+    }
+
+    /// Creates a new key binding from a modifier and optional key
+    pub fn new_keycode(modifiers: impl Into<Modifiers>, key: Option<xkb::Keycode>) -> Binding {
+        Binding {
+            description: None,
+            modifiers: modifiers.into(),
+            keycode: None,
+            key: None,
         }
     }
 

--- a/config/src/shortcuts/mod.rs
+++ b/config/src/shortcuts/mod.rs
@@ -159,6 +159,7 @@ impl Shortcuts {
         &mut self,
         modifiers: Modifiers,
         keys: impl Iterator<Item = xkb::Keysym>,
+        keycodes: impl Iterator<Item = xkb::Keycode>,
         action: Action,
     ) {
         if !self.0.values().any(|a| a == &action) {
@@ -166,7 +167,19 @@ impl Shortcuts {
                 let pattern = Binding {
                     description: None,
                     modifiers: modifiers.clone(),
+                    keycode: None,
                     key: Some(key),
+                };
+                if !self.0.contains_key(&pattern) {
+                    self.0.insert(pattern, action.clone());
+                }
+            }
+            for key in keycodes {
+                let pattern = Binding {
+                    description: None,
+                    modifiers: modifiers.clone(),
+                    keycode: Some(key.raw()),
+                    key: None,
                 };
                 if !self.0.contains_key(&pattern) {
                     self.0.insert(pattern, action.clone());


### PR DESCRIPTION
Currently unused, but could be used instead of keysym for custom keybinds