### PR TITLE
fix: missing icons in GTK apps

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -151,6 +151,7 @@ pub async fn watch_theme(
     };
 
     set_gnome_button_layout(tk.show_maximize, tk.show_minimize);
+    set_gnome_icon_theme(tk.icon_theme.clone());
 
     let light_helper = CosmicTheme::light_config()?;
     let dark_helper = CosmicTheme::dark_config()?;


### PR DESCRIPTION
Sync the COSMIC icon theme with `gsettings set org.gnome.desktop.interface icon-theme` on startup.

This was only being being set when the icon theme is changed, so installs that haven't manually changed the icon theme will not have the cosmic icon theme set for GTK.