### PR TITLE
fix: don't uppercase keysym first letter

### DIFF
--- a/config/src/shortcuts/binding.rs
+++ b/config/src/shortcuts/binding.rs
@@ -158,7 +158,7 @@ impl Binding {
         }
 
         if let Some(key) = self.key {
-            string.push_str(&uppercase_first_letter(&xkb::keysym_get_name(key)));
+            string.push_str(&xkb::keysym_get_name(key));
         } else if !string.is_empty() {
             string.remove(string.len() - 1);
         }


### PR DESCRIPTION
Capitalizing the first letter may cause issues with recognition of certain keysyms https://github.com/pop-os/cosmic-settings/issues/1449