### PR TITLE
Don't print errors for `ErrorKind::NotFound` from `CosmicTk`

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -144,6 +144,12 @@ pub async fn watch_theme(
         Ok(t) => t,
         Err((errs, t)) => {
             for why in errs {
+                if let cosmic_config::Error::GetKey(_, err) = &why {
+                    if err.kind() == std::io::ErrorKind::NotFound {
+                        // No system default config installed; don't error
+                        continue;
+                    }
+                }
                 log::error!("{why}");
             }
             t


### PR DESCRIPTION
Same change as https://github.com/pop-os/libcosmic/pull/949.

Now `cosmic-settings-daemon` prints nothing at start, instead of a few errors.