### PR TITLE
Set icon theme and button layout for GNOME only if requested

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -156,13 +156,13 @@ pub async fn watch_theme(
         }
     };
 
-    set_gnome_button_layout(tk.show_maximize, tk.show_minimize);
-    set_gnome_icon_theme(tk.icon_theme.clone());
-
     let light_helper = CosmicTheme::light_config()?;
     let dark_helper = CosmicTheme::dark_config()?;
 
     if tk.apply_theme_global {
+        set_gnome_button_layout(tk.show_maximize, tk.show_minimize);
+        set_gnome_icon_theme(tk.icon_theme.clone());
+
         // Write the gtk variables for both themes in case they have changed in the meantime
         let dark = match Theme::get_entry(&dark_helper) {
             Ok(t) => t,
@@ -295,12 +295,14 @@ pub async fn watch_theme(
                             log::error!("Error updating the theme toolkit config {err:?}");
                         }
 
-                        if changes.contains(&"icon_theme") {
-                            set_gnome_icon_theme(tk.icon_theme.clone());
-                        }
+                        if tk.apply_theme_global {
+                            if changes.contains(&"icon_theme") {
+                                set_gnome_icon_theme(tk.icon_theme.clone());
+                            }
 
-                        if changes.contains(&"show_maximize") || changes.contains(&"show_minimize") {
-                            set_gnome_button_layout(tk.show_maximize, tk.show_minimize);
+                            if changes.contains(&"show_maximize") || changes.contains(&"show_minimize") {
+                                set_gnome_button_layout(tk.show_maximize, tk.show_minimize);
+                            }
                         }
 
                         if !changes.contains(&"apply_theme_global") {
@@ -308,6 +310,9 @@ pub async fn watch_theme(
                         }
 
                         if tk.apply_theme_global {
+                            set_gnome_icon_theme(tk.icon_theme.clone());
+                            set_gnome_button_layout(tk.show_maximize, tk.show_minimize);
+
                             // Write the gtk variables for both themes in case they have changed in the meantime
                             let dark = match Theme::get_entry(&dark_helper) {
                                 Ok(t) => t,


### PR DESCRIPTION
This ensures that the icon theme and button layout for GNOME applications are not overwritten at login or when changed in the settings if the `apply_theme_global` setting is disabled. This allows users to decide whether they want COSMIC to modify GNOME settings.