### PR TITLE
Add GSettings override file to set default settings for COSMIC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ endif
 BIN = cosmic-settings-daemon
 SYSTEM_ACTIONS_CONF = "$(DESTDIR)$(sharedir)/cosmic/com.system76.CosmicSettings.Shortcuts/v1/system_actions"
 POLKIT_RULE = "$(DESTDIR)$(sharedir)/polkit-1/rules.d/cosmic-settings-daemon.rules"
+GSETTINGS_OVERRIDE = "$(DESTDIR)$(sharedir)/glib-2.0/schemas/30_com.system76.Cosmic.gschema.override"
 
 all: $(BIN)
 
@@ -37,6 +38,7 @@ install:
 	install -Dm0755 "$(CARGO_TARGET_DIR)/$(TARGET)/$(BIN)" "$(DESTDIR)$(bindir)/$(BIN)"
 	install -Dm0644 "data/system_actions.ron" "$(SYSTEM_ACTIONS_CONF)"
 	install -Dm0644 "data/polkit-1/rules.d/cosmic-settings-daemon.rules" "$(POLKIT_RULE)"
+	install -Dm0644 "data/30_com.system76.Cosmic.gschema.override" "$(GSETTINGS_OVERRIDE)"
 
 ## Cargo Vendoring
 

--- a/data/30_com.system76.Cosmic.gschema.override
+++ b/data/30_com.system76.Cosmic.gschema.override
@@ -1,0 +1,5 @@
+[org.gnome.desktop.interface:COSMIC]
+icon-theme='Cosmic'
+
+[org.gnome.desktop.wm.preferences:COSMIC]
+button-layout=':minimize,maximize,close'

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -156,9 +156,6 @@ pub async fn watch_theme(
         }
     };
 
-    set_gnome_button_layout(tk.show_maximize, tk.show_minimize);
-    set_gnome_icon_theme(tk.icon_theme.clone());
-
     let light_helper = CosmicTheme::light_config()?;
     let dark_helper = CosmicTheme::dark_config()?;
 


### PR DESCRIPTION
Instead of overwriting the button layout and icon theme setting at every login, set session-dependent defaults with a GSettings override file.