### PR TITLE
feat: Add Kill action to shortcuts

### DIFF
--- a/config/src/shortcuts/action.rs
+++ b/config/src/shortcuts/action.rs
@@ -12,6 +12,9 @@ pub enum Action {
     /// Show a debug overlay, if enabled in the compositor build
     Debug,
 
+    /// Force kill the active window and its process
+    Kill,
+
     /// Disable a default shortcut binding
     Disable,
 


### PR DESCRIPTION
This pull request introduces a new action to the `Action` enum in `config/src/shortcuts/action.rs`, allowing for force-killing the active window and its process.

New shortcut action:

* Added a `Kill` variant to the `Action` enum to support force-killing the active window and its process.