### PR TITLE
Set PW media role to Notification for sounds (cosmic-settings #1017)

### DIFF
--- a/src/pipewire.rs
+++ b/src/pipewire.rs
@@ -12,6 +12,8 @@ pub fn play(path: &Path) {
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::inherit())
+        .arg("--media-role")
+        .arg("Notification")
         .arg(path)
         .spawn();
 }


### PR DESCRIPTION
Notification sounds are currently played by spawning pw-play.  By adding `--media-role Notification` to the command, the output will be properly recognized as a notification sound, and can thus be controlled by, eg, pavucontrol's System Sounds control.  This addresses https://github.com/pop-os/cosmic-settings/issues/1017 .