### PR TITLE
Refine unmuting logic to trigger only on volume increase

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -298,13 +298,6 @@ impl SettingsDaemon {
         let limit = if amplification_enabled { "1.5" } else { "1.0" };
 
         if let Err(e) = self
-            .run_wpctl(&["set-mute", "@DEFAULT_AUDIO_SINK@", "0"])
-            .await
-        {
-            log::error!("Failed to unmute audio: {}", e);
-        }
-
-        if let Err(e) = self
             .run_wpctl(&["set-volume", "@DEFAULT_AUDIO_SINK@", "5%-", "-l", limit])
             .await
         {


### PR DESCRIPTION
Ensure the player remains muted during volume decreases or static adjustments; unmute only when volume is actively increased.

Implemented volume control logic to align with the modern Linux Desktop UX standard. This 'silent-by-default' paradigm—where 'Volume Down' decrements the audio level while strictly persisting the 'Mute' state—became the standard expectation starting with the GNOME 40 / libadwaita 1.0 (2021-2022) and KDE Plasma 5.25 / Frameworks 5.95 (2022) desktop cycles.
Consequently, this behavior is now native to their respective core applications, such as GNOME Videos (Totem) v40.0+ and KDE's Elisa Music Player v22.04+ (KDE Gear). To maintain parity with these applications, our master volume down input acts as a passive level adjustment; only an explicit 'Volume Up' command or a direct toggle acts as an active unmute trigger.

Tandem pull request: [cosmic-player #238](https://github.com/pop-os/cosmic-player/pull/238)

AI was used to generate this code.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.