### PR TITLE
debian: allow users to remove qt5ct/qt6ct

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,6 @@ Architecture: amd64 arm64
 Depends:
   acpid,
   adw-gtk3,
-  qt6ct,
   pop-sound-theme,
   ${misc:Depends},
   ${shlibs:Depends}
@@ -28,4 +27,5 @@ Recommends:
   breeze-icon-theme,
   playerctl,
   qt5ct,
+  qt6ct,
 Description: Cosmic settings daemon

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,6 @@ Architecture: amd64 arm64
 Depends:
   acpid,
   adw-gtk3,
-  qt5ct,
   qt6ct,
   pop-sound-theme,
   ${misc:Depends},
@@ -28,4 +27,5 @@ Depends:
 Recommends:
   breeze-icon-theme,
   playerctl,
+  qt5ct,
 Description: Cosmic settings daemon


### PR DESCRIPTION
Qt5's open-source support ended 08 Dec 2020 and commercial support ended 25 May 2025.
Since it's EOL, this changes qt5ct from Depends to Recommends.

I think it still makes sense to theme qt5 apps, but this makes it possible for power users to remove qt5ct if they wish.

Previous discussion: https://gitlab.archlinux.org/archlinux/packaging/packages/cosmic-settings-daemon/-/merge_requests/1

***

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

