### PR TITLE
feat: generate QPalette for wider Qt compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,19 +774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmic-client-toolkit"
-version = "0.2.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?rev=160b086#160b086abe03cd34a8a375d7fbe47b24308d1f38"
-dependencies = [
- "bitflags 2.11.0",
- "cosmic-protocols",
- "libc",
- "smithay-client-toolkit",
- "wayland-client",
- "wayland-protocols",
-]
-
-[[package]]
 name = "cosmic-comp-config"
 version = "1.0.0"
 source = "git+https://github.com/pop-os/cosmic-comp#40c7eb26cd5e625678d618a755845a741a910287"
@@ -799,7 +786,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -819,7 +806,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -848,20 +835,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmic-protocols"
-version = "0.2.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?rev=160b086#160b086abe03cd34a8a375d7fbe47b24308d1f38"
-dependencies = [
- "bitflags 2.11.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-protocols-wlr",
- "wayland-scanner",
- "wayland-server",
-]
-
-[[package]]
 name = "cosmic-settings-config"
 version = "0.1.0"
 dependencies = [
@@ -870,7 +843,7 @@ dependencies = [
  "serde",
  "serde_with",
  "tracing",
- "xkbcommon 0.9.0",
+ "xkbcommon",
 ]
 
 [[package]]
@@ -963,7 +936,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "almost",
  "configparser",
@@ -2232,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "dnd",
  "iced_core",
@@ -2251,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -2274,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -2284,7 +2257,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "futures",
  "iced_core",
@@ -2297,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -2318,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -2327,7 +2300,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2339,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "bytes",
  "dnd",
@@ -2353,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2370,12 +2343,11 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.11.0",
  "bytemuck",
- "cosmic-client-toolkit",
  "cryoglyph",
  "futures",
  "glam 0.25.0",
@@ -2401,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -2836,7 +2808,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/adil192/libcosmic?rev=db35a10c645a9863a47166aa939f7cfd2c94aa6a#db35a10c645a9863a47166aa939f7cfd2c94aa6a"
+source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
 dependencies = [
  "apply",
  "auto_enums",
@@ -4551,14 +4523,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
  "bitflags 2.11.0",
- "bytemuck",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
  "libc",
  "log",
  "memmap2",
- "pkg-config",
  "rustix 1.1.4",
  "thiserror 2.0.18",
  "wayland-backend",
@@ -4570,7 +4540,6 @@ dependencies = [
  "wayland-protocols-misc",
  "wayland-protocols-wlr",
  "wayland-scanner",
- "xkbcommon 0.8.0",
  "xkeysym",
 ]
 
@@ -5589,7 +5558,6 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
- "wayland-server",
 ]
 
 [[package]]
@@ -5629,7 +5597,6 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "wayland-scanner",
- "wayland-server",
 ]
 
 [[package]]
@@ -5641,19 +5608,6 @@ dependencies = [
  "proc-macro2",
  "quick-xml 0.39.2",
  "quote",
-]
-
-[[package]]
-name = "wayland-server"
-version = "0.31.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63736a4a73e781cf6a736aa32c5d6773c3eb5389197562742a8c611b49b5e359"
-dependencies = [
- "bitflags 2.11.0",
- "downcast-rs",
- "rustix 1.1.4",
- "wayland-backend",
- "wayland-scanner",
 ]
 
 [[package]]
@@ -6392,17 +6346,6 @@ dependencies = [
 
 [[package]]
 name = "xkbcommon"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d66ca9352cbd4eecbbc40871d8a11b4ac8107cfc528a6e14d7c19c69d0e1ac9"
-dependencies = [
- "libc",
- "memmap2",
- "xkeysym",
-]
-
-[[package]]
-name = "xkbcommon"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a974f48060a14e95705c01f24ad9c3345022f4d97441b8a36beb7ed5c4a02d"
@@ -6417,9 +6360,6 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,14 +883,14 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
  "cosmic-settings-daemon 0.1.0 (git+https://github.com/pop-os/dbus-settings-bindings)",
  "dirs",
  "futures-util",
- "iced_futures",
+ "iced_futures 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
  "known-folders",
  "notify",
  "ron 0.12.0",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -1016,7 +1016,7 @@ source = "git+https://github.com/pop-os/cosmic-settings-subscriptions#f858ca0b64
 dependencies = [
  "async-fn-stream",
  "futures",
- "iced_futures",
+ "iced_futures 0.14.0-dev (git+https://github.com/pop-os/libcosmic)",
  "itertools",
  "libcosmic",
  "libpulse-binding",
@@ -1055,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
 dependencies = [
  "almost",
  "configparser",
@@ -2377,11 +2377,11 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
 dependencies = [
  "dnd",
- "iced_core",
- "iced_futures",
+ "iced_core 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
+ "iced_futures 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
  "iced_renderer",
  "iced_widget",
  "image",
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -2414,12 +2414,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "iced_core"
+version = "0.14.0-dev"
+source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "dnd",
+ "glam 0.25.0",
+ "log",
+ "mime 0.1.0",
+ "num-traits",
+ "once_cell",
+ "palette",
+ "raw-window-handle",
+ "rustc-hash 2.1.1",
+ "smol_str 0.2.2",
+ "thiserror 1.0.69",
+ "web-time",
+ "window_clipboard",
+]
+
+[[package]]
+name = "iced_futures"
+version = "0.14.0-dev"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+dependencies = [
+ "futures",
+ "iced_core 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
+ "log",
+ "rustc-hash 2.1.1",
+ "wasm-bindgen-futures",
+ "wasm-timer",
+]
+
+[[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
 source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
 dependencies = [
  "futures",
- "iced_core",
+ "iced_core 0.14.0-dev (git+https://github.com/pop-os/libcosmic)",
  "log",
  "rustc-hash 2.1.1",
  "wasm-bindgen-futures",
@@ -2441,14 +2476,14 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "cosmic-text",
  "half",
- "iced_core",
- "iced_futures",
+ "iced_core 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
+ "iced_futures 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
  "image",
  "kamadak-exif",
  "log",
@@ -2463,7 +2498,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2475,12 +2510,12 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
 dependencies = [
  "bytes",
  "dnd",
- "iced_core",
- "iced_futures",
+ "iced_core 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
+ "iced_futures 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
  "raw-window-handle",
  "thiserror 1.0.69",
  "window_clipboard",
@@ -2489,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2505,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.11.0",
@@ -2536,7 +2571,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -3012,7 +3047,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
+source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
 dependencies = [
  "apply",
  "auto_enums",
@@ -3026,8 +3061,8 @@ dependencies = [
  "i18n-embed",
  "i18n-embed-fl",
  "iced",
- "iced_core",
- "iced_futures",
+ "iced_core 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
+ "iced_futures 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
  "iced_renderer",
  "iced_runtime",
  "iced_tiny_skia",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,14 +883,14 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
  "cosmic-settings-daemon 0.1.0 (git+https://github.com/pop-os/dbus-settings-bindings)",
  "dirs",
  "futures-util",
- "iced_futures 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
+ "iced_futures",
  "known-folders",
  "notify",
  "ron 0.12.0",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -1016,7 +1016,7 @@ source = "git+https://github.com/pop-os/cosmic-settings-subscriptions#f858ca0b64
 dependencies = [
  "async-fn-stream",
  "futures",
- "iced_futures 0.14.0-dev (git+https://github.com/pop-os/libcosmic)",
+ "iced_futures",
  "itertools",
  "libcosmic",
  "libpulse-binding",
@@ -1055,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "almost",
  "configparser",
@@ -2377,11 +2377,11 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "dnd",
- "iced_core 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
- "iced_futures 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
+ "iced_core",
+ "iced_futures",
  "iced_renderer",
  "iced_widget",
  "image",
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -2414,47 +2414,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "iced_core"
-version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
-dependencies = [
- "bitflags 2.11.0",
- "bytes",
- "dnd",
- "glam 0.25.0",
- "log",
- "mime 0.1.0",
- "num-traits",
- "once_cell",
- "palette",
- "raw-window-handle",
- "rustc-hash 2.1.1",
- "smol_str 0.2.2",
- "thiserror 1.0.69",
- "web-time",
- "window_clipboard",
-]
-
-[[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "futures",
- "iced_core 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
- "log",
- "rustc-hash 2.1.1",
- "wasm-bindgen-futures",
- "wasm-timer",
-]
-
-[[package]]
-name = "iced_futures"
-version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#85c27a99604f343bfa0fb2d78e6726f511f6a57a"
-dependencies = [
- "futures",
- "iced_core 0.14.0-dev (git+https://github.com/pop-os/libcosmic)",
+ "iced_core",
  "log",
  "rustc-hash 2.1.1",
  "wasm-bindgen-futures",
@@ -2476,14 +2441,14 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "cosmic-text",
  "half",
- "iced_core 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
- "iced_futures 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
+ "iced_core",
+ "iced_futures",
  "image",
  "kamadak-exif",
  "log",
@@ -2498,7 +2463,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2510,12 +2475,12 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "bytes",
  "dnd",
- "iced_core 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
- "iced_futures 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
+ "iced_core",
+ "iced_futures",
  "raw-window-handle",
  "thiserror 1.0.69",
  "window_clipboard",
@@ -2524,7 +2489,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2540,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.11.0",
@@ -2571,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -3047,7 +3012,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23#9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23"
+source = "git+https://github.com/adil192/libcosmic?rev=490090878b0f5ac0fc919e1d65e4739f23a239d7#490090878b0f5ac0fc919e1d65e4739f23a239d7"
 dependencies = [
  "apply",
  "auto_enums",
@@ -3061,8 +3026,8 @@ dependencies = [
  "i18n-embed",
  "i18n-embed-fl",
  "iced",
- "iced_core 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
- "iced_futures 0.14.0-dev (git+https://github.com/adil192/libcosmic?rev=9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23)",
+ "iced_core",
+ "iced_futures",
  "iced_renderer",
  "iced_runtime",
  "iced_tiny_skia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ log = "0.4.28"
 env_logger = "0.11.8"
 
 # For development and testing purposes
-# [patch.'https://github.com/pop-os/libcosmic']
-# libcosmic = { path = "../libcosmic" }
-# cosmic-config = { path = "../libcosmic/cosmic-config" }
-# cosmic-theme = { path = "../libcosmic/cosmic-theme" }
+[patch.'https://github.com/pop-os/libcosmic']
+libcosmic = { git = "https://github.com/adil192/libcosmic", rev = "9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23" }
+cosmic-config = { git = "https://github.com/adil192/libcosmic", rev = "9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23" }
+cosmic-theme = { git = "https://github.com/adil192/libcosmic", rev = "9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ log = "0.4.28"
 env_logger = "0.11.8"
 
 # For development and testing purposes
-[patch.'https://github.com/pop-os/libcosmic']
-libcosmic = { git = "https://github.com/adil192/libcosmic", rev = "db35a10c645a9863a47166aa939f7cfd2c94aa6a" }
-iced_futures = { git = "https://github.com/adil192/libcosmic", rev = "db35a10c645a9863a47166aa939f7cfd2c94aa6a" }
-cosmic-config = { git = "https://github.com/adil192/libcosmic", rev = "db35a10c645a9863a47166aa939f7cfd2c94aa6a" }
-cosmic-theme = { git = "https://github.com/adil192/libcosmic", rev = "db35a10c645a9863a47166aa939f7cfd2c94aa6a" }
+# [patch.'https://github.com/pop-os/libcosmic']
+# libcosmic = { git = "https://github.com/pop-os/libcosmic//" }
+# iced_futures = { git = "https://github.com/pop-os/libcosmic//" }
+# cosmic-config = { git = "https://github.com/pop-os/libcosmic//" }
+# cosmic-theme = { git = "https://github.com/pop-os/libcosmic//" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ env_logger = "0.11.8"
 
 # For development and testing purposes
 [patch.'https://github.com/pop-os/libcosmic']
-libcosmic = { git = "https://github.com/adil192/libcosmic", rev = "9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23" }
-cosmic-config = { git = "https://github.com/adil192/libcosmic", rev = "9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23" }
-cosmic-theme = { git = "https://github.com/adil192/libcosmic", rev = "9f330cb56aafcd43bf3b0d4ade1fae0b286e6e23" }
+libcosmic = { git = "https://github.com/adil192/libcosmic", rev = "490090878b0f5ac0fc919e1d65e4739f23a239d7" }
+cosmic-config = { git = "https://github.com/adil192/libcosmic", rev = "490090878b0f5ac0fc919e1d65e4739f23a239d7" }
+cosmic-theme = { git = "https://github.com/adil192/libcosmic", rev = "490090878b0f5ac0fc919e1d65e4739f23a239d7" }
+iced_futures = { git = "https://github.com/adil192/libcosmic", rev = "490090878b0f5ac0fc919e1d65e4739f23a239d7" }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -632,6 +632,12 @@ fn set_flatpak_overrides() {
     ];
 
     tokio::spawn(async {
+        _ = tokio::process::Command::new("flatpak")
+            .arg("override")
+            .arg("--user")
+            .arg("--env=QT_QPA_PLATFORMTHEME=kde")
+            .status()
+            .await;
         for path in paths_to_expose {
             _ = tokio::process::Command::new("flatpak")
                 .arg("override")


### PR DESCRIPTION
This PR bumps libcosmic to my forked version from:
- https://github.com/pop-os/libcosmic/pull/1170.

Note that this was forked from https://github.com/pop-os/libcosmic/commit/85c27a99604f343bfa0fb2d78e6726f511f6a57a before all the "chore: update iced" commits since I assumed they were unstable.

Qt theming is now working on Pop!_OS (24.04).
Previously, it only worked with patched versions of qt5ct and qt6ct that are distributed by e.g. Fedora and the AUR.

Testing instructions:
1. Install this version of cosmic-settings-daemon: `make && sudo make install`
2. Install cosmic-session from https://github.com/pop-os/cosmic-session/pull/192
   or just copy those changes into `/usr/bin/start-cosmic`.
3. Restart or logout&login.

***

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
- [X] (Done) Don't merge this as-is since it uses my fork of libcosmic. After approval, we'll merge the libcosmic PR then change this to the official repo.