### PR TITLE
feat: WindowRules Workspace Assignment

### DIFF
--- a/config/src/window_rules/mod.rs
+++ b/config/src/window_rules/mod.rs
@@ -35,12 +35,21 @@ pub struct PreciseApplicationException {
     pub enabled: bool,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct WorkspaceAssignment {
+    pub appid: String,
+    pub title: String,
+    pub enabled: bool,
+    pub workspace_id: String,
+}
+
 // cosmic-config configuration state for `com.system76.CosmicSettings.WindowRules`
 #[derive(Clone, Debug, Default, PartialEq, CosmicConfigEntry)]
 #[version = 1]
 pub struct Config {
     pub tiling_exception_defaults: Vec<DefaultApplicationException>,
     pub tiling_exception_custom: Vec<PreciseApplicationException>,
+    pub workspace_assignment: Vec<WorkspaceAssignment>,
 }
 
 impl Config {
@@ -77,13 +86,12 @@ pub fn tiling_exceptions(context: &cosmic_config::Config) -> Vec<ApplicationExce
     let custom = context
         .get::<Vec<PreciseApplicationException>>("tiling_exception_custom")
         .unwrap_or_else(|why| {
-            if why.is_err() {
-                if let cosmic_config::Error::GetKey(_, err) = &why {
-                    if err.kind() != std::io::ErrorKind::NotFound {
-                        tracing::error!("tiling exceptions custom config error: {why}");
-                        return Vec::new();
-                    }
-                }
+            if why.is_err()
+                && let cosmic_config::Error::GetKey(_, err) = &why
+                && err.kind() != std::io::ErrorKind::NotFound
+            {
+                tracing::error!("tiling exceptions custom config error: {why}");
+                return Vec::new();
             }
             tracing::debug!("tiling exceptions custom config not present: {why}");
             Vec::new()
@@ -111,6 +119,40 @@ pub fn tiling_exceptions(context: &cosmic_config::Config) -> Vec<ApplicationExce
                 Some(ApplicationException {
                     appid: exception.appid.clone(),
                     title: exception.title.clone(),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Get the current workspace assignment configuration
+pub fn workspace_assignments(context: &cosmic_config::Config) -> Vec<WorkspaceAssignment> {
+    // Load custom assignments defined by the user.
+    let custom = context
+        .get::<Vec<WorkspaceAssignment>>("workspace_assignment_custom")
+        .unwrap_or_else(|why| {
+            if why.is_err()
+                && let cosmic_config::Error::GetKey(_, err) = &why
+                && err.kind() != std::io::ErrorKind::NotFound
+            {
+                tracing::error!("workspace assignment custom config error: {why}");
+                return Vec::new();
+            }
+            tracing::debug!("workspace assignment custom config not present: {why}");
+            Vec::new()
+        });
+
+    custom
+        .iter()
+        .filter_map(|assignment| {
+            if assignment.enabled {
+                Some(WorkspaceAssignment {
+                    appid: assignment.appid.clone(),
+                    title: assignment.title.clone(),
+                    enabled: true, // Currently unused.
+                    workspace_id: assignment.workspace_id.clone(),
                 })
             } else {
                 None

--- a/config/src/window_rules/mod.rs
+++ b/config/src/window_rules/mod.rs
@@ -40,7 +40,7 @@ pub struct WorkspaceAssignment {
     pub appid: String,
     pub title: String,
     pub enabled: bool,
-    pub workspace_id: String,
+    pub workspace_name: String,
 }
 
 // cosmic-config configuration state for `com.system76.CosmicSettings.WindowRules`
@@ -152,7 +152,7 @@ pub fn workspace_assignments(context: &cosmic_config::Config) -> Vec<WorkspaceAs
                     appid: assignment.appid.clone(),
                     title: assignment.title.clone(),
                     enabled: true, // Currently unused.
-                    workspace_id: assignment.workspace_id.clone(),
+                    workspace_name: assignment.workspace_name.clone(),
                 })
             } else {
                 None

--- a/config/src/window_rules/mod.rs
+++ b/config/src/window_rules/mod.rs
@@ -35,12 +35,21 @@ pub struct PreciseApplicationException {
     pub enabled: bool,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct WorkspaceAssignment {
+    pub appid: String,
+    pub title: String,
+    pub enabled: bool,
+    pub workspace_id: String,
+}
+
 // cosmic-config configuration state for `com.system76.CosmicSettings.WindowRules`
 #[derive(Clone, Debug, Default, PartialEq, CosmicConfigEntry)]
 #[version = 1]
 pub struct Config {
     pub tiling_exception_defaults: Vec<DefaultApplicationException>,
     pub tiling_exception_custom: Vec<PreciseApplicationException>,
+    pub workspace_assignment: Vec<WorkspaceAssignment>,
 }
 
 impl Config {
@@ -110,6 +119,40 @@ pub fn tiling_exceptions(context: &cosmic_config::Config) -> Vec<ApplicationExce
                 Some(ApplicationException {
                     appid: exception.appid.clone(),
                     title: exception.title.clone(),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Get the current workspace assignment configuration
+pub fn workspace_assignments(context: &cosmic_config::Config) -> Vec<WorkspaceAssignment> {
+    // Load custom assignments defined by the user.
+    let custom = context
+        .get::<Vec<WorkspaceAssignment>>("workspace_assignment_custom")
+        .unwrap_or_else(|why| {
+            if why.is_err()
+                && let cosmic_config::Error::GetKey(_, err) = &why
+                && err.kind() != std::io::ErrorKind::NotFound
+            {
+                tracing::error!("workspace assignment custom config error: {why}");
+                return Vec::new();
+            }
+            tracing::debug!("workspace assignment custom config not present: {why}");
+            Vec::new()
+        });
+
+    custom
+        .iter()
+        .filter_map(|assignment| {
+            if assignment.enabled {
+                Some(WorkspaceAssignment {
+                    appid: assignment.appid.clone(),
+                    title: assignment.title.clone(),
+                    enabled: true, // Currently unused.
+                    workspace_id: assignment.workspace_id.clone(),
                 })
             } else {
                 None


### PR DESCRIPTION
### Feature

Extend `WindowRules` enabling launching applications/windows on specific workspaces instead of the current active workspace.

Required for: https://github.com/pop-os/cosmic-comp/pull/2214

### How to use

Assign workspace names.

Pin workspaces using UI or via file:

```sh
$ cat ~/.config/cosmic/com.system76.CosmicComp/v1/pinned_workspaces 
[
    (
        output: (
            name: "eDP-1",
            edid: None,
        ),
        tiling_enabled: true,
        id: Some("11f90a5"),
        name: Some("terminal"),
    ),
    (
        output: (
            name: "eDP-1",
            edid: None,
        ),
        tiling_enabled: true,
        id: Some("b382cb"),
        name: Some("browser"),
    ),
]
```

Define Workspace Assignment configuration file with matching `name`'s:

```sh
$ cat ~/.config/cosmic/com.system76.CosmicSettings.WindowRules/v1/workspace_assignment_custom
[
  (
    enabled: true,
    appid: "kitty",
    title: ".*",
    workspace_name: "terminal"
  ),
  (
    enabled: true,
    appid: "firefox",
    title: ".*",
    workspace_name: "browser"
  )
]

```

Disable the window rule by setting `enabled: false`.

### Testing

1. branch based off flake changes in: https://github.com/pop-os/cosmic-settings-daemon/pull/138
   1. Validate package builds: `nix build`
   2. Development shell builds: `nix develop` and then `cargo check` 
2. cosmic-comp build and execute per https://github.com/pop-os/cosmic-comp/pull/2214
3. NixOS overlay replacing upstream with my fork and this branch.

### Note to reviewers

This is my first contribution to Cosmic and I may have misunderstood or completely missed project structure/styling or other conventions. Please let me know and I'll rework accordingly. Thank you!

- "workspace assignment" naming chosen based off i3wm:
  `assign [class="<application_class>"] <workspace_number>`
- separate file `path/to/WindowRules/workspace_assignment_custom` because it appears to be convention to have a file per feature, rather than a catch all `../WindowRules/window_rules` with features: sticky, tiling exceptions, workspace assignment, etc
- left `workspace_assignment_defaults` free for implementation if required.

### AI Disclosure

No AI generated code in the development of this PR.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

