### PR TITLE
fix: use more permissive denylist for bare shortcut key validation

### DIFF
--- a/config/src/shortcuts/binding.rs
+++ b/config/src/shortcuts/binding.rs
@@ -112,10 +112,7 @@ impl Binding {
         (self.has_modifier() && self.key.is_some())
             || self.is_super()
             || self.key.map_or(false, |key| {
-                // Allow Home/End, Print, PageDown/Up, etc.
-                key.is_misc_function_key()
-                    // XF86 keysym range
-                    || matches!(key.raw(), 0x10080001..=0x1008FFFF)
+                !is_forbidden_unmodified_keysym(key)
             })
     }
 
@@ -298,4 +295,41 @@ mod tests {
         // At least one key is required.
         assert!(matches!(Binding::from_str(" "), Err(_)));
     }
+}
+
+pub fn is_forbidden_unmodified_keysym(key: xkb::Keysym) -> bool {
+    let raw = key.raw();
+    matches!(raw,
+        0x0041..=0x005a   | // A-Z
+        0x0061..=0x007a   | // a-z
+        0x0030..=0x0039   | // 0-9
+        0x0020            | // Space
+        0xff09            | // Tab
+        0xfe20            | // ISO_Left_Tab
+        0xff89            | // KP_Tab
+        0xff0d            | // Return
+        0xff8d            | // KP_Enter
+        0xff7e            | // Mode_switch
+        0xff14            | // Scroll_Lock
+        0xff15            | // Sys_Req
+        0xff20            | // Multi_key (Compose)
+        0xff7f            | // Num_Lock
+        0xffe5            | // Caps_Lock
+        0xfe01            | // ISO_Lock
+        0xfe08            | // ISO_Next_Group
+        0xfe0a            | // ISO_Prev_Group
+        0xfe0c            | // ISO_First_Group
+        0xfe0e            | // ISO_Last_Group
+        0xfed0..=0xfed2   | // First/Prev/Next_Virtual_Screen
+        0xfed4            | // Last_Virtual_Screen
+        0xfed5            | // Terminate_Server
+        0xfe7a            | // AudibleBell_Enable
+        0x04a1..=0x04df   | // Kana (Japanese)
+        0x05ac..=0x05f2   | // Arabic
+        0x06a1..=0x06ff   | // Cyrillic
+        0x07a1..=0x07f9   | // Greek
+        0x0cdf..=0x0cfa   | // Hebrew
+        0x0da1..=0x0df9   | // Thai
+        0x0ea1..=0x0efa     // Hangul (Korean)
+    )
 }

--- a/config/src/shortcuts/mod.rs
+++ b/config/src/shortcuts/mod.rs
@@ -8,7 +8,7 @@ pub mod modifier;
 pub use modifier::{Modifier, Modifiers, ModifiersDef};
 
 mod binding;
-pub use binding::Binding;
+pub use binding::{is_forbidden_unmodified_keysym, Binding};
 
 pub mod sym;
 


### PR DESCRIPTION
# 1 of 2 Pull Requests

- This PR targets:
  - https://github.com/pop-os/cosmic-settings/issues/597.
- This PR is a prerequisite for:
  - https://github.com/pop-os/cosmic-settings/pull/1930

## Problems

The current `Binding::is_set()` uses an allowlist with `is_misc_function_key()` to determine which keys can be used as standalone shortcuts without a modifier. This blocks function keys (F1-F24), uncommon characters (like `²` on AZERTY keyboards), and other non-typing keys that users commonly bind.

## Solutions

This PR switches to a much more permissive denylist approach, blocking only keys that would interfere with normal typing. Everything else is allowed, including F1-F24, media keys, and uncommon characters.

Any modifier (Shift, Ctrl, Alt, or Super) bypasses the denylist entirely.

Due to the more explicit nature of a denylist, I've opted to keep a single source of truth in `is_forbidden_unmodified_keysym` instead of continuing with the previously succinct but duplicated logic.

<img width="589" height="729" alt="image" src="https://github.com/user-attachments/assets/7f7b5f5b-f03a-497f-b9d8-c3c6b2881276" />

## North Star

I compared the existing behaviors of both Gnome and KDE for this pull request for user expectation alignment and cautious boundaries:
- There should be no allowed characters here that are blocked by both Gnome _and_ KDE.
- There should be no disallowed characters here that were previously allowed by Cosmic. 

| Bare Keys| COSMIC (Before) | COSMIC (After) | GNOME | KDE |
|---|---|---|---|---|
| F1-F24 | ❌ | ✅ | ✅ | ✅ |
| Media keys | ✅ | ✅ | ✅ | ✅ |
| Print, Insert, etc. | ✅ | ✅ | ✅ | ✅ |
| Letters (a-z) | ❌ | ❌ | ❌ | ❌ |
| Digits (0-9) | ❌ | ❌ | ❌ | ❌ |
| Space | ❌ | ❌ | ❌ | ❌ |
| Navigation (arrows, Home, etc.) | ❌ | ✅ | ❌ | ✅ |
| Tab, Enter | ❌ | ❌ | ❌ | ❌ |
| Backspace, Delete | ❌ | ✅ | ✅ | ❌ |
| Dedicated punctuation keys (!@#$) | ❌ | ✅ | ✅ | ❌ |
| ², ³, µ, © | ❌ | ✅ | ✅ | ❌ |
| Escape | ❌ (cancel) | ❌ (cancel) | ❌ (cancel) | ✅ |

## Enabling F13-F24

This is mostly for macro users. By default these keys are redirected to special codes (media, etc) for historical purposes. Most modern keyboards now send media codes and don't require this remapping. No settings UI is provided by this PR to toggle this option:

 ```ron
 // ~/.config/cosmic/com.system76.CosmicComp/v1/xkb_config
 (
     rules: "",
     model: "",
     layout: "us",
     variant: "",
     options: Some("fkeys:basic_13-24"), // this line enables F13-F24
     repeat_delay: 600,
     repeat_rate: 25,
 )
```

 ---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
