### PR TITLE
fix(cosmic-theme): complementary should be dark not light

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -806,7 +806,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "almost",
  "configparser",
@@ -2205,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "dnd",
  "iced_core",
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -2247,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -2257,7 +2257,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "futures",
  "iced_core",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -2300,7 +2300,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2312,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "bytes",
  "dnd",
@@ -2326,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.11.0",
@@ -2373,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -2808,7 +2808,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic#f06d15ae35204cb3bcef5a3188b5ec59a1cc9bfd"
+source = "git+https://github.com/adil192/libcosmic?branch=test%2Fqt_theme#47ac8aab445fadcfd248a3d25ca360826fee4048"
 dependencies = [
  "apply",
  "auto_enums",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ log = "0.4.28"
 env_logger = "0.11.8"
 
 # For development and testing purposes
-# [patch.'https://github.com/pop-os/libcosmic']
-# libcosmic = { git = "https://github.com/pop-os/libcosmic//" }
-# iced_futures = { git = "https://github.com/pop-os/libcosmic//" }
-# cosmic-config = { git = "https://github.com/pop-os/libcosmic//" }
-# cosmic-theme = { git = "https://github.com/pop-os/libcosmic//" }
+[patch.'https://github.com/pop-os/libcosmic']
+libcosmic = { git = "https://github.com/adil192/libcosmic", branch = "test/qt_theme" }
+iced_futures = { git = "https://github.com/adil192/libcosmic", branch = "test/qt_theme" }
+cosmic-config = { git = "https://github.com/adil192/libcosmic", branch = "test/qt_theme" }
+cosmic-theme = { git = "https://github.com/adil192/libcosmic", branch = "test/qt_theme" }


### PR DESCRIPTION
Dependency PR to allow you to test the small fix included in https://github.com/pop-os/libcosmic/pull/1208

Update: Closed because this is a tiny change that 99.999% of apps won't use, so it's not really worth review time. It can be picked up the next time you bump libcosmic.

***

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
- [ ] This is using my fork, don't merge as-is

