### PR TITLE
feat: Action::Snap variant + DisplayBrightnessHotkey signal

### DIFF
--- a/config/src/shortcuts/action.rs
+++ b/config/src/shortcuts/action.rs
@@ -87,6 +87,10 @@ pub enum Action {
     /// Resize the active window in a given direction
     Resizing(ResizeDirection),
 
+    /// Windows-style snap: half/quarter the active window in the given direction.
+    /// Chained presses transition: Left then Down → BottomLeft quarter, etc.
+    Snap(Direction),
+
     /// Move a window to the last workspace
     SendToLastWorkspace,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,6 +219,12 @@ impl SettingsDaemon {
     #[zbus(property)]
     async fn set_keyboard_brightness(&self, _value: i32) {}
 
+    #[zbus(signal)]
+    async fn display_brightness_hotkey(
+        emitter: &SignalEmitter<'_>,
+        new_brightness: i32,
+    ) -> zbus::Result<()>;
+
     async fn increase_display_brightness(
         &self,
         #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
@@ -229,6 +235,7 @@ impl SettingsDaemon {
             let target = next_target_raw(value, max_raw, 1);
             self.set_display_brightness(target).await;
             _ = self.display_brightness_changed(&emitter).await;
+            _ = Self::display_brightness_hotkey(&emitter, target).await;
         }
     }
 
@@ -242,6 +249,7 @@ impl SettingsDaemon {
             let target = next_target_raw(value, max_raw, -1);
             self.set_display_brightness(target).await;
             _ = self.display_brightness_changed(&emitter).await;
+            _ = Self::display_brightness_hotkey(&emitter, target).await;
         }
     }
 


### PR DESCRIPTION
## Summary

Two small additions that enable downstream features in `cosmic-comp` and `cosmic-osd`:

* **`Action::Snap(Direction)`** on the shortcut Action enum — a new system action that compositors can bind to a key combo to snap the focused window to a screen edge. Lets users wire `Super+Arrow` (or whatever) to a window-snap shortcut. The actual snap behaviour lives in the compositor; this PR is just the action variant so the keybind config can reference it.
* **`DisplayBrightnessHotkey` D-Bus signal** — emitted from `display_brightness_increase` / `display_brightness_decrease` in addition to the existing property-change signal. Lets OSD daemons distinguish hotkey-driven brightness changes from programmatic backlight writes (e.g. dim-on-idle), so the brightness slider only pops up when the user actually pressed a key.

## Motivation

* **Snap action**: today there's no built-in way to bind keyboard window-snapping; users either patch the compositor with hardcoded keybinds or run a sidecar tool. Adding the variant keeps the shortcut-config surface consistent and lets the compositor own the actual snap geometry.
* **Hotkey signal**: any program that fades the backlight on idle (cosmic-idle dim stage, accessibility tools, screen savers) currently triggers the brightness OSD on every fade frame. Routing the user-facing path through a separate signal lets OSD code subscribe selectively.

## Implementation

* `config/src/shortcuts/action.rs` — adds `Snap(Direction)` next to the existing `MoveWindow(Direction)` / similar variants. Reuses the existing `Direction` type.
* `src/main.rs` — adds a `display_brightness_hotkey` signal to the daemon's D-Bus interface and emits it from the two brightness hotkey methods.

## Testing

Built and running on my daily-driver COSMIC desktop; the corresponding compositor + OSD patches consume both additions correctly. No existing behaviour changes — the property-change signal still fires on every brightness write as before.

## AI Disclosure

Patches were drafted with assistance from Claude (Anthropic). Commits include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` trailers. I understand each change and will respond to review feedback. I'm aware of the AI-PR policy in the template — happy to rework or close if maintainers prefer.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.