### PR TITLE
Changed device type confirmation to depend on confirmed available rat…

### DIFF
--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -180,8 +180,8 @@ pub(crate) async fn pulse(
                         }
                     },
                     pulse::Event::CardInfo(info) => {
-                        if info.ports.iter().any(|port| matches!(port.port_type, PortType::Headphones) && matches!(port.availability, Availability::Yes | Availability::Unknown)) &&
-                            info.ports.iter().any(|port| matches!(port.port_type, PortType::Headset) && matches!(port.availability, Availability::Unknown))
+                        if info.ports.iter().any(|port| matches!(port.port_type, PortType::Headphones) && matches!(port.availability, Availability::Yes)) &&
+                            info.ports.iter().any(|port| matches!(port.port_type, PortType::Headset) && matches!(port.availability, Availability::Yes))
                         {
                             let card_name = &info.name;
                             let Some((headphone_port, headphone_profile, headphone_avail)) = info.ports.iter().find(|port| matches!(port.port_type, PortType::Headphones)).and_then(|port| port.profiles.iter().max_by_key(|p| p.priority).map(|prof| (port.name.clone(), prof, port.availability))) else {


### PR DESCRIPTION
A fix for the pop-up that prompts to "confirm device type" when there is no audio device connected.

This fixes #146

I used AI-generated instructions from Devin, as per https://deepwiki.com/search/how-can-i-prevent-changing-ava_b1e738c0-b968-4157-bf68-a48aafc51f59?mode=fast. I understand the logic around how to handle availability changes reported by Pulse.

I have tested that this works on my laptop which was affected by the issue.


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

