### PR TITLE
Add ambient light sensor probe

### DIFF
--- a/src/ambient_light/backend.rs
+++ b/src/ambient_light/backend.rs
@@ -1,0 +1,109 @@
+use crate::ambient_light::sensor_proxy::SensorProxyProxy;
+use crate::ambient_light::sysfs::SysfsAls;
+
+#[derive(Debug)]
+pub enum AmbientLightBackend {
+    SensorProxy(SensorProxyProxy<'static>),
+    Sysfs(SysfsAls),
+}
+
+impl AmbientLightBackend {
+    pub async fn detect() -> Option<Self> {
+        if let Some(proxy) = Self::detect_sensor_proxy().await {
+            return Some(AmbientLightBackend::SensorProxy(proxy));
+        }
+
+        SysfsAls::new().map(|sysfs_als| {
+            log::info!(
+                "ambient-light: using sysfs fallback at {:?}",
+                sysfs_als.path()
+            );
+            AmbientLightBackend::Sysfs(sysfs_als)
+        })
+    }
+
+    async fn detect_sensor_proxy() -> Option<SensorProxyProxy<'static>> {
+        log::debug!("ambient-light: trying iio-sensor-proxy over system D-Bus");
+
+        let conn = match zbus::Connection::system().await {
+            Ok(conn) => conn,
+            Err(err) => {
+                log::debug!("ambient-light: system D-Bus is not available: {err:?}");
+                return None;
+            }
+        };
+
+        let proxy = match SensorProxyProxy::builder(&conn).build().await {
+            Ok(proxy) => proxy,
+            Err(err) => {
+                log::debug!("ambient-light: failed to build iio-sensor-proxy client: {err:?}");
+                return None;
+            }
+        };
+
+        match proxy.has_ambient_light().await {
+            Ok(true) => {}
+            Ok(false) => {
+                log::debug!("ambient-light: iio-sensor-proxy reports no ambient light sensor");
+                return None;
+            }
+            Err(err) => {
+                log::warn!("ambient-light: failed to read HasAmbientLight: {err:?}");
+                return None;
+            }
+        }
+
+        match proxy.light_level_unit().await {
+            Ok(unit) if unit == "lux" => {}
+            Ok(unit) => {
+                log::warn!(
+                    "ambient-light: iio-sensor-proxy light unit is {unit:?}, expected \"lux\""
+                );
+                return None;
+            }
+            Err(err) => {
+                log::warn!("ambient-light: failed to read LightLevelUnit: {err:?}");
+                return None;
+            }
+        }
+
+        match proxy.claim_light().await {
+            Ok(()) => Some(proxy),
+            Err(err) => {
+                log::warn!("ambient-light: failed to claim iio-sensor-proxy light sensor: {err:?}");
+                None
+            }
+        }
+    }
+
+    pub async fn read_lux(&self) -> Option<f64> {
+        match self {
+            AmbientLightBackend::SensorProxy(proxy) => match proxy.light_level().await {
+                Ok(lux) => Some(lux),
+                Err(err) => {
+                    log::warn!("ambient-light: failed to read LightLevel: {err:?}");
+                    None
+                }
+            },
+            AmbientLightBackend::Sysfs(sysfs_als) => sysfs_als.read_lux(),
+        }
+    }
+
+    pub async fn release(&self) {
+        match self {
+            AmbientLightBackend::SensorProxy(proxy) => {
+                if let Err(err) = proxy.release_light().await {
+                    log::debug!("ambient-light: failed to release iio-sensor-proxy claim: {err:?}");
+                }
+            }
+            AmbientLightBackend::Sysfs(_) => {}
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            AmbientLightBackend::SensorProxy(_) => "iio-sensor-proxy",
+            AmbientLightBackend::Sysfs(_) => "sysfs",
+        }
+    }
+}

--- a/src/ambient_light/mod.rs
+++ b/src/ambient_light/mod.rs
@@ -1,0 +1,37 @@
+use tokio::sync::broadcast;
+
+pub mod backend;
+pub mod sensor_proxy;
+pub mod sysfs;
+
+pub use backend::AmbientLightBackend;
+
+pub async fn monitor(mut shutdown_rx: broadcast::Receiver<()>) {
+    log::info!("ambient-light: starting ambient light sensor probe");
+
+    let Some(backend) = AmbientLightBackend::detect().await else {
+        log::warn!("ambient-light: no ambient light sensor backend detected");
+        return;
+    };
+
+    log::info!("ambient-light: using {} backend", backend.name());
+
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.recv() => {
+                log::info!("ambient-light: stopping ambient light sensor probe");
+                backend.release().await;
+                break;
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {
+                if let Some(lux) = backend.read_lux().await {
+                    log::info!(
+                        "ambient-light: backend={} lux={:.3}",
+                        backend.name(),
+                        lux
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/ambient_light/sensor_proxy.rs
+++ b/src/ambient_light/sensor_proxy.rs
@@ -1,0 +1,19 @@
+#[zbus::proxy(
+    default_service = "net.hadess.SensorProxy",
+    interface = "net.hadess.SensorProxy",
+    default_path = "/net/hadess/SensorProxy"
+)]
+pub trait SensorProxy {
+    fn claim_light(&self) -> zbus::Result<()>;
+
+    fn release_light(&self) -> zbus::Result<()>;
+
+    #[zbus(property)]
+    fn has_ambient_light(&self) -> zbus::Result<bool>;
+
+    #[zbus(property)]
+    fn light_level(&self) -> zbus::Result<f64>;
+
+    #[zbus(property)]
+    fn light_level_unit(&self) -> zbus::Result<String>;
+}

--- a/src/ambient_light/sysfs.rs
+++ b/src/ambient_light/sysfs.rs
@@ -1,0 +1,148 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct SysfsAls {
+    device_path: PathBuf,
+}
+
+impl SysfsAls {
+    pub fn new() -> Option<Self> {
+        Self::new_from(Path::new("/sys/bus/iio/devices"))
+    }
+
+    fn new_from(iio_dir: &Path) -> Option<Self> {
+        let entries = fs::read_dir(iio_dir).ok()?;
+
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+
+            if !file_name.starts_with("iio:device") {
+                continue;
+            }
+
+            let Ok(name) = fs::read_to_string(path.join("name")) else {
+                continue;
+            };
+
+            if is_als_name(name.trim()) && path.join("in_illuminance_raw").exists() {
+                log::debug!("ambient-light: found sysfs device at {:?}", path);
+                return Some(Self { device_path: path });
+            }
+        }
+
+        None
+    }
+
+    pub fn read_lux(&self) -> Option<f64> {
+        let raw = read_f64(&self.device_path.join("in_illuminance_raw"))?;
+        let scale_path = self.device_path.join("in_illuminance_scale");
+        let scale = if scale_path.exists() {
+            read_f64(&scale_path)?
+        } else {
+            1.0
+        };
+
+        Some(raw * scale)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.device_path
+    }
+}
+
+fn is_als_name(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    name == "als" || name.contains("ambient") || name.contains("light")
+}
+
+fn read_f64(path: &Path) -> Option<f64> {
+    fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new() -> Self {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "cosmic-settings-daemon-als-test-{}-{nanos}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self { path }
+        }
+
+        fn device(&self, name: &str, raw: Option<&str>, scale: Option<&str>) -> PathBuf {
+            let path = self.path.join("iio:device0");
+            fs::create_dir(&path).unwrap();
+            fs::write(path.join("name"), name).unwrap();
+            if let Some(raw) = raw {
+                fs::write(path.join("in_illuminance_raw"), raw).unwrap();
+            }
+            if let Some(scale) = scale {
+                fs::write(path.join("in_illuminance_scale"), scale).unwrap();
+            }
+            path
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn detects_case_insensitive_als_name() {
+        let dir = TestDir::new();
+        let device = dir.device("Ambient Light", Some("42"), Some("0.5"));
+
+        let als = SysfsAls::new_from(&dir.path).unwrap();
+
+        assert_eq!(als.path(), device.as_path());
+        assert_eq!(als.read_lux(), Some(21.0));
+    }
+
+    #[test]
+    fn ignores_devices_without_illuminance_raw() {
+        let dir = TestDir::new();
+        dir.device("als", None, Some("0.5"));
+
+        assert!(SysfsAls::new_from(&dir.path).is_none());
+    }
+
+    #[test]
+    fn uses_scale_one_when_scale_file_is_absent() {
+        let dir = TestDir::new();
+        dir.device("als", Some("42"), None);
+
+        let als = SysfsAls::new_from(&dir.path).unwrap();
+
+        assert_eq!(als.read_lux(), Some(42.0));
+    }
+
+    #[test]
+    fn returns_none_when_scale_is_invalid() {
+        let dir = TestDir::new();
+        dir.device("als", Some("42"), Some("nope"));
+
+        let als = SysfsAls::new_from(&dir.path).unwrap();
+
+        assert_eq!(als.read_lux(), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use zbus::{
     object_server::SignalEmitter,
     zvariant::ObjectPath,
 };
+mod ambient_light;
 mod battery;
 mod brightness_device;
 mod greeter;
@@ -627,6 +628,10 @@ async fn main() -> zbus::Result<()> {
             });
 
             tokio::task::spawn_local(battery::monitor());
+
+            if std::env::var("COSMIC_AMBIENT_LIGHT_PROBE").is_ok() {
+                tokio::task::spawn_local(ambient_light::monitor(sigterm_rx.resubscribe()));
+            }
 
             let conn_clone = connection.clone();
             task::spawn_local(async move {


### PR DESCRIPTION
This adds a probe-only ambient light sensor backend to cosmic-settings-daemon.

The primary backend uses iio-sensor-proxy over D-Bus. If that is unavailable, reports no ALS, has an unreadable LightLevelUnit, or reports a unit other than lux, the probe falls back to generic IIO sysfs devices exposing in_illuminance_raw and optional in_illuminance_scale.

This change does not alter display brightness. The probe only runs when COSMIC_AMBIENT_LIGHT_PROBE is set, and logs detected lux values for debugging. Without that environment variable, the daemon does not claim iio-sensor-proxy or scan sysfs.

Motivation:
On some systems, including ASUS Zenbook 14 UX3405CA, the kernel exposes an ambient light sensor through IIO/sysfs, while iio-sensor-proxy may fail to expose it. This keeps the initial daemon-side change limited to detection and debugging before any automatic brightness behavior is considered.

Testing:
- `cargo test`
- `cargo clippy --all-targets --all-features`
- `rustfmt --edition 2024 --check src/main.rs src/ambient_light/mod.rs src/ambient_light/backend.rs src/ambient_light/sensor_proxy.rs src/ambient_light/sysfs.rs`





