### PR TITLE
feat: graceful restart with SIGHUP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,6 @@ dependencies = [
  "cosmic-settings-daemon-config",
  "cosmic-settings-varlink-server",
  "cosmic-theme",
- "ctrlc",
  "ddc-hi",
  "dirs",
  "futures",
@@ -1173,17 +1172,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
 dependencies = [
  "dtor",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
-dependencies = [
- "dispatch2",
- "nix 0.31.3",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1422,8 +1410,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "libc",
  "objc2",
 ]
 
@@ -3132,7 +3118,7 @@ dependencies = [
  "cookie-factory",
  "libc",
  "libspa-sys",
- "nix 0.30.1",
+ "nix",
  "nom 8.0.0",
  "system-deps",
 ]
@@ -3541,18 +3527,6 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -4036,7 +4010,7 @@ dependencies = [
  "libc",
  "libspa",
  "libspa-sys",
- "nix 0.30.1",
+ "nix",
  "once_cell",
  "pipewire-sys",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ cosmic-settings-daemon-config = { path = "./cosmic-settings-daemon-config", feat
 cosmic-settings-varlink-server = { path = "./varlink-server" }
 cosmic-theme.export = true
 cosmic-theme.workspace = true
-ctrlc = { version = "3.5.0", features = ["termination"] }
 ddc-hi = "0.4.1"
 dirs = "6.0.0"
 futures = "0.3.31"
@@ -45,7 +44,7 @@ notify = "8.2.0"
 notify-rust = "4.11.7"
 serde = "1.0.228"
 sunrise = "2.1.0"
-tokio = { version = "1.47.1", features = ["macros", "net", "rt"] }
+tokio = { version = "1.47.1", features = ["macros", "net", "rt", "signal"] }
 tokio-stream = "0.1.17"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,28 +6,23 @@ use cosmic_config::ConfigGet;
 use futures::lock::Mutex;
 use logind_session::LogindSessionProxy;
 use notify::{EventKind, Watcher, event::ModifyKind};
-use std::sync::atomic::AtomicU64;
+use std::os::unix::process::CommandExt;
+use std::process::ExitCode;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::time::Duration;
 use std::{
-    collections::{HashMap, HashSet},
-    io,
-    path::PathBuf,
-    sync::{Arc, atomic::Ordering},
+    collections::{HashMap, HashSet}, io, path::PathBuf, sync::{Arc, atomic::Ordering}
 };
 use theme::watch_theme;
+use tokio::signal::unix::SignalKind;
 use tokio::{
-    io::{Interest, unix::AsyncFd},
-    sync::RwLock,
-    task,
+    io::{Interest, unix::AsyncFd}, sync::RwLock, task
 };
 use tokio_stream::StreamExt;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use zbus::{
-    Connection, MatchRule, MessageStream,
-    names::{MemberName, UniqueName, WellKnownName},
-    object_server::SignalEmitter,
-    zvariant::ObjectPath,
+    Connection, MatchRule, MessageStream, names::{MemberName, UniqueName, WellKnownName}, object_server::SignalEmitter, zvariant::ObjectPath
 };
 mod battery;
 mod brightness_device;
@@ -443,7 +438,33 @@ pub enum Change {
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> zbus::Result<()> {
+async fn main() -> ExitCode {
+    let restart_signal = Arc::new(AtomicBool::new(false));
+    let current_exe = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.canonicalize().ok());
+
+    let signal_term_fut = std::pin::pin!({
+        let restart_signal = Arc::clone(&restart_signal);
+        let sigint = tokio::signal::unix::signal(SignalKind::interrupt()).ok();
+        let sigterm = tokio::signal::unix::signal(SignalKind::terminate()).ok();
+        let sighup = tokio::signal::unix::signal(SignalKind::hangup()).ok();
+        async move {
+            let Some(((mut sigint, mut sigterm), mut sighup)) = sigint.zip(sigterm).zip(sighup)
+            else {
+                return futures::future::pending().await;
+            };
+
+            tokio::select! {
+                _ = sigint.recv() => {}
+                _ = sigterm.recv() => {}
+                _ = sighup.recv() => {
+                    restart_signal.store(true, Ordering::Relaxed);
+                }
+            }
+        }
+    });
+
     let log_format = tracing_subscriber::fmt::format()
         .pretty()
         .without_time()
@@ -461,19 +482,11 @@ async fn main() -> zbus::Result<()> {
         .with(log_layer)
         .init();
 
-    let (theme_cleanup_done_tx, mut theme_cleanup_done_rx) = tokio::sync::mpsc::channel(1);
-    let (sigterm_tx, sigterm_rx) = tokio::sync::broadcast::channel(1);
-
-    ctrlc::set_handler(move || {
-        sigterm_tx.send(()).unwrap();
-    })
-    .expect("Error setting sigterm handler");
-
     if let Err(err) = greeter::sync_with_greeter() {
         log::error!("Failed to sync with greeter. {err:?}");
     }
 
-    task::LocalSet::new()
+    let result: zbus::Result<()> = task::LocalSet::new()
         .run_until(async move {
             let (varlink_daemon, varlink_backend) = cosmic_settings_varlink_server::init().await;
             let varlink_daemon_context = varlink_daemon.0.clone();
@@ -625,21 +638,18 @@ async fn main() -> zbus::Result<()> {
             });
 
             let (theme_tx, mut theme_rx) = tokio::sync::mpsc::channel(10);
-            task::spawn_local(async move {
+            let (theme_cancel_tx, mut theme_cancel_rx) = tokio::sync::mpsc::channel::<()>(1);
+            let theme_watcher_fut = std::pin::pin!(async move {
                 let mut sleep = Duration::from_millis(100);
 
                 loop {
-                    if let Err(err) = watch_theme(
-                        &mut theme_rx,
-                        theme_cleanup_done_tx.clone(),
-                        sigterm_rx.resubscribe(),
-                    )
-                    .await
-                    {
+                    if let Err(err) = watch_theme(&mut theme_rx, &mut theme_cancel_rx).await {
                         log::error!(
                             "Failed to watch theme {err:?}. Will try again in {}s",
                             sleep.as_secs()
                         );
+                    } else {
+                        break;
                     }
                     tokio::time::sleep(sleep).await;
                     sleep = sleep.saturating_mul(2);
@@ -654,7 +664,7 @@ async fn main() -> zbus::Result<()> {
             });
 
             let conn_clone = connection.clone();
-            task::spawn(async move {
+            let main_fut = std::pin::pin!(async move {
                 while let Some(changes) = rx.recv().await {
                     let Ok(settings_daemon) = conn_clone
                         .object_server()
@@ -761,11 +771,27 @@ async fn main() -> zbus::Result<()> {
                 }
             });
 
-            _ = theme_cleanup_done_rx.recv().await;
-
+            futures::future::join(theme_watcher_fut, async move {
+                futures::future::select(signal_term_fut, main_fut).await;
+                _ = theme_cancel_tx.send(()).await;
+            })
+            .await;
+            _ = cosmic_theme::Theme::reset_exports();
             Ok(())
         })
-        .await
+        .await;
+
+    ExitCode::from(if restart_signal.load(Ordering::Relaxed) {
+        if let Some(current_exe) = current_exe {
+            _ = std::process::Command::new(current_exe).exec();
+        }
+        1
+    } else if let Err(why) = result {
+        eprintln!("cosmic-settings-daemon failed: {why}");
+        1
+    } else {
+        0
+    })
 }
 
 async fn watch_config_message_stream(

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -123,8 +123,7 @@ impl SunriseSunset {
 
 pub async fn watch_theme(
     theme_mode_rx: &mut tokio::sync::mpsc::Receiver<ThemeMsg>,
-    cleanup_tx: tokio::sync::mpsc::Sender<()>,
-    mut sigterm_rx: tokio::sync::broadcast::Receiver<()>,
+    theme_cancel_rx: &mut tokio::sync::mpsc::Receiver<()>,
 ) -> anyhow::Result<()> {
     let mut override_until_next = false;
 
@@ -231,12 +230,10 @@ pub async fn watch_theme(
         };
 
         tokio::select! {
-            _ = sigterm_rx.recv() => {
-                if let Err(err) = Theme::reset_exports() {
-                    log::error!("Failed to reset the cosmic theme exports. {err:?}");
-                }
-                cleanup_tx.send(()).await.unwrap();
+            _ = theme_cancel_rx.recv() => {
+                return Ok(());
             }
+
             changes = theme_mode_rx.recv() => {
                 let Some(changes) = changes else {
                     bail!("Theme mode changes failed");


### PR DESCRIPTION
Allows the settings daemon to restart itself on receiving a SIGHUP signal (`kill -1 $(pidof cosmic-settings-daemon)`). This can be used to restart the settings daemon when an update requires it.

---
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

