### PR TITLE
fix(theme): unset flatpak override for QT_QPA_PLATFORMTHEME

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -629,12 +629,15 @@ fn set_flatpak_overrides() {
     ];
 
     tokio::spawn(async {
-        _ = tokio::process::Command::new("flatpak")
-            .arg("override")
-            .arg("--user")
-            .arg("--env=QT_QPA_PLATFORMTHEME=kde")
-            .status()
-            .await;
+        // Unset incorrectly-defined platform theme.
+        if let Some(mut overrides_path) = std::env::home_dir() {
+            overrides_path = overrides_path.join(".local/share/flatpak/overrides/global");
+            if let Ok(mut overrides) = tokio::fs::read_to_string(&overrides_path).await {
+                overrides = overrides.replace("\nQT_QPA_PLATFORMTHEME=kde", "");
+                _ = tokio::fs::write(&overrides_path, overrides.as_bytes()).await;
+            }
+        }
+
         for path in paths_to_expose {
             _ = tokio::process::Command::new("flatpak")
                 .arg("override")


### PR DESCRIPTION
This override is not necessary and sets the wrong value.

---
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

