### PR TITLE
Revert "fix(theme): unset flatpak override for QT_QPA_PLATFORMTHEME"

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -629,15 +629,12 @@ fn set_flatpak_overrides() {
     ];
 
     tokio::spawn(async {
-        // Unset incorrectly-defined platform theme.
-        if let Some(mut overrides_path) = std::env::home_dir() {
-            overrides_path = overrides_path.join(".local/share/flatpak/overrides/global");
-            if let Ok(mut overrides) = tokio::fs::read_to_string(&overrides_path).await {
-                overrides = overrides.replace("\nQT_QPA_PLATFORMTHEME=kde", "");
-                _ = tokio::fs::write(&overrides_path, overrides.as_bytes()).await;
-            }
-        }
-
+        _ = tokio::process::Command::new("flatpak")
+            .arg("override")
+            .arg("--user")
+            .arg("--env=QT_QPA_PLATFORMTHEME=kde")
+            .status()
+            .await;
         for path in paths_to_expose {
             _ = tokio::process::Command::new("flatpak")
                 .arg("override")


### PR DESCRIPTION
Reverts #166.
Without this flatpak override, flatpak QT theming via the `~/.config/kdeglobals` file does not work as demonstrated in the screenshots below.
This was tested on Fedora 44 with COSMIC 1.3.0 built from source.


#### Before revert:
`flatpak run --env=QT_QPA_PLATFORMTHEME= org.prismlauncher.PrismLauncher`
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/439b1313-6f55-4414-a366-228faed412a7" />

#### After revert:
`flatpak run --env=QT_QPA_PLATFORMTHEME=kde org.prismlauncher.PrismLauncher`
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/5fdb024e-80e5-42a0-adfd-768a48eebbe8" />


***

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

