### PR TITLE
fix(brightness): drop cached DDC handles when idle

### DIFF
--- a/src/brightness_device.rs
+++ b/src/brightness_device.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::io;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::{fs, time};
 
 use crate::LogindSessionProxy;
@@ -35,33 +35,47 @@ impl BrightnessDevice {
         let v: Arc<(Mutex<Option<u16>>, std::sync::Condvar)> =
             Arc::new((Mutex::new(Some(100u16)), std::sync::Condvar::new()));
         let brightness_dcc = v.clone();
-        let mut displays = Display::enumerate();
-        let displays_empty = displays.is_empty();
+        let displays_empty = Display::enumerate().is_empty();
 
         std::thread::spawn(move || {
-            let mut cur = 100;
-            let mut last_change = Instant::now();
-            loop {
-                let v = v.clone();
-                let mut guard = v.0.lock().unwrap();
-                while guard.is_some_and(|v| v == cur) {
-                    guard = v.1.wait(guard).unwrap();
-                }
+            // How long cached DDC display handles are kept after the last
+            // brightness change. Each handle is an open fd on a /dev/i2c-*
+            // adapter; holding them indefinitely blocks the kernel's DP-MST
+            // teardown on monitor unplug, permanently wedging drm_dp_mst_wq
+            // (https://github.com/pop-os/cosmic-settings-daemon/issues/165).
+            // The cache still avoids re-enumeration during a burst of
+            // brightness key repeats.
+            const IDLE_TIMEOUT: Duration = Duration::from_secs(2);
 
-                let Some(brightness) = *guard else {
-                    break;
+            let mut displays: Vec<Display> = Vec::new();
+            let mut cur = 100;
+            'outer: loop {
+                let brightness = {
+                    let mut guard = v.0.lock().unwrap();
+                    loop {
+                        match *guard {
+                            None => break 'outer,
+                            Some(b) if b != cur => break b,
+                            Some(_) => {}
+                        }
+                        if displays.is_empty() {
+                            guard = v.1.wait(guard).unwrap();
+                        } else {
+                            let (g, res) = v.1.wait_timeout(guard, IDLE_TIMEOUT).unwrap();
+                            guard = g;
+                            if res.timed_out() {
+                                // Idle: release the i2c fds so unplugged
+                                // displays can be torn down by the kernel.
+                                displays.clear();
+                            }
+                        }
+                    }
                 };
-                drop(guard);
 
                 cur = brightness;
-                let now = Instant::now();
-                if now.checked_duration_since(last_change).unwrap_or_default()
-                    > Duration::from_secs(10)
-                {
-                    // pull in latest case anything has changed...
+                if displays.is_empty() {
                     displays = Display::enumerate();
                 }
-                last_change = now;
                 for display in &mut displays {
                     if display.update_capabilities().is_err() {
                         continue;


### PR DESCRIPTION
Fixes #165

`BrightnessDevice::external()` moved the enumerated `Display` handles (open `/dev/i2c-*` fds) into the brightness thread and held them for the daemon's lifetime — they were only re-enumerated when the next brightness change arrived >10s after the previous one. An open fd on the i2c adapter of an unplugged DP-MST monitor blocks the kernel's MST teardown (`drm_dp_delayed_destroy_work` → `i2c_del_adapter` waits for every user of the adapter), permanently wedging `drm_dp_mst_wq`: hung-task warnings, stalled hotplug handling, and stale connectors that break saved output configurations on replug. Full analysis in #165.

This change keeps the handle cache only while brightness changes are actively arriving: the thread waits on the condvar with a 2s timeout while handles are held, and drops them once no change arrives within that window. Bursts of brightness key repeats still reuse the cached handles; an idle daemon holds no i2c fds, so MST teardown can complete.

Verified on the machine from #165 (NixOS, i915, Thunderbolt dock, Samsung LS27A80 via MST), running this patch backported onto 1.2.0:

- idle daemon holds **0** open `/dev/i2c-*` fds (previously 4, held indefinitely)
- triggering a brightness change over D-Bus opens the fds, performs the DDC write, and drops them ~2s after the last change
- the teardown deadlock requires an open fd on the unplugged adapter, which no longer exists outside an active brightness change (in #165, releasing the fds immediately unblocked the stuck kworker)

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
