### PR TITLE
feat(audio): expose application playback streams

### DIFF
--- a/audio-core/src/lib.rs
+++ b/audio-core/src/lib.rs
@@ -123,6 +123,14 @@ pub struct RouteInfo {
     pub is_sink: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+pub enum NodeKind {
+    Sink,
+    Source,
+    /// A per-application playback stream (sink-input equivalent).
+    StreamOutput,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NodeInfo {
     pub name: String,
@@ -130,7 +138,18 @@ pub struct NodeInfo {
     pub device_profile_description: String,
     pub device_id: Option<u32>,
     pub card_profile_device: Option<u32>,
+    /// Retained for compatibility with existing audio clients.
     pub is_sink: bool,
+    /// The complete node classification. `None` is sent by older daemons.
+    pub kind: Option<NodeKind>,
+    /// `application.name` — set only for stream nodes.
+    pub application_name: Option<String>,
+    /// `application.process.binary` — set only for stream nodes.
+    pub application_binary: Option<String>,
+    /// `application.icon-name` — preferred icon name for stream nodes.
+    pub application_icon_name: Option<String>,
+    /// `media.name` — current media title, set only for stream nodes.
+    pub media_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/audio-server/src/backend.rs
+++ b/audio-server/src/backend.rs
@@ -68,7 +68,6 @@ pub struct Model {
     sink_node_ids: Vec<NodeId>,
     /// Node IDs for sources
     source_node_ids: Vec<NodeId>,
-
     /** Device object information */
 
     /// Information about devices that are shared with subscribed varlink clients.
@@ -915,13 +914,26 @@ impl Model {
                     self.node_devices.insert(node.object_id, device_id);
                 }
 
+                let kind = match node.media_class {
+                    pipewire::MediaClass::Sink => cosmic_settings_audio_core::NodeKind::Sink,
+                    pipewire::MediaClass::Source => cosmic_settings_audio_core::NodeKind::Source,
+                    pipewire::MediaClass::StreamOutput => {
+                        cosmic_settings_audio_core::NodeKind::StreamOutput
+                    }
+                };
+
                 let info = cosmic_settings_audio_core::NodeInfo {
                     name: node.node_name.clone(),
                     description: node.description,
                     device_profile_description: node.device_profile_description,
                     device_id: node.device_id,
                     card_profile_device: node.card_profile_device,
-                    is_sink: matches!(node.media_class, pipewire::MediaClass::Sink),
+                    is_sink: matches!(kind, cosmic_settings_audio_core::NodeKind::Sink),
+                    kind: Some(kind),
+                    application_name: node.application_name.clone(),
+                    application_binary: node.application_binary.clone(),
+                    application_icon_name: node.application_icon_name.clone(),
+                    media_name: node.media_name.clone(),
                 };
 
                 self.emit_event(Event::Node(node.object_id, info.clone()))
@@ -967,6 +979,8 @@ impl Model {
                             }
                         }
                     }
+
+                    pipewire::MediaClass::StreamOutput => {}
                 }
 
                 self.node_info.insert(node.object_id, info.clone());
@@ -1032,8 +1046,13 @@ impl Model {
     }
 
     fn node_id_from_name(&self, name: &str, is_sink: bool) -> Option<u32> {
+        let expected_kind = if is_sink {
+            cosmic_settings_audio_core::NodeKind::Sink
+        } else {
+            cosmic_settings_audio_core::NodeKind::Source
+        };
         self.node_info.iter().find_map(|(id, n)| {
-            if n.name == name && n.is_sink == is_sink {
+            if n.name == name && n.kind == Some(expected_kind) {
                 Some(id)
             } else {
                 None

--- a/cosmic-pipewire/src/node.rs
+++ b/cosmic-pipewire/src/node.rs
@@ -25,6 +25,14 @@ pub struct Node {
     pub media_class: MediaClass,
     pub node_name: String,
     pub state: State,
+    /// `application.name` — human-readable app name, set on stream nodes.
+    pub application_name: Option<String>,
+    /// `application.process.binary` — binary name, set on stream nodes.
+    pub application_binary: Option<String>,
+    /// `application.icon-name` — preferred icon name, set on stream nodes.
+    pub application_icon_name: Option<String>,
+    /// `media.name` — current media title (e.g. track/tab title), set on stream nodes.
+    pub media_name: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -40,6 +48,8 @@ pub enum State {
 pub enum MediaClass {
     Source,
     Sink,
+    /// `Stream/Output/Audio` — a per-application playback stream (sink-input equivalent).
+    StreamOutput,
 }
 
 impl Node {
@@ -59,6 +69,11 @@ impl Node {
         let mut node_description: &str = "";
         let mut node_name = String::new();
         let mut object_id = None;
+        let mut application_name = None;
+        let mut application_binary = None;
+        let mut application_icon_name = None;
+        let mut application_process_id: Option<u32> = None;
+        let mut media_name = None;
 
         for (entry, value) in props.iter() {
             match entry {
@@ -89,6 +104,7 @@ impl Node {
                     media_class = Some(match value {
                         "Audio/Sink" => MediaClass::Sink,
                         "Audio/Source" => MediaClass::Source,
+                        "Stream/Output/Audio" => MediaClass::StreamOutput,
                         _ => return None,
                     })
                 }
@@ -99,8 +115,31 @@ impl Node {
                 // Family 17h/19h HD Audio Controller Analog Stereo
                 "node.description" => node_description = value,
 
+                // Firefox, Spotify (set on stream nodes)
+                "application.name" => application_name = Some(value.to_owned()),
+
+                // firefox, spotify (set on stream nodes)
+                "application.process.binary" => application_binary = Some(value.to_owned()),
+
+                // Present on streams created by a user application, but absent
+                // from PipeWire's own loopback and combined-output nodes.
+                "application.process.id" => application_process_id = value.parse().ok(),
+
+                // application-set icon name, preferred over icon-by-binary-name lookup
+                "application.icon-name" => application_icon_name = Some(value.to_owned()),
+
+                // current track/tab title (set on stream nodes)
+                "media.name" => media_name = Some(value.to_owned()),
+
                 _ => (),
             }
+        }
+
+        // Playback controls should enumerate user applications, not PipeWire's
+        // internal loopback or combined-output streams.
+        if matches!(media_class, Some(MediaClass::StreamOutput)) && application_process_id.is_none()
+        {
+            return None;
         }
 
         let device = Node {
@@ -130,6 +169,10 @@ impl Node {
                 NodeState::Suspended => State::Suspended,
                 NodeState::Error(why) => State::Error(why.to_owned()),
             },
+            application_name,
+            application_binary,
+            application_icon_name,
+            media_name,
         };
 
         Some(device)

--- a/cosmic-pipewire/src/node.rs
+++ b/cosmic-pipewire/src/node.rs
@@ -52,6 +52,15 @@ pub enum MediaClass {
     StreamOutput,
 }
 
+/// Whether a playback stream belongs to PipeWire's internal routing graph.
+///
+/// PipeWire's loopback and combined-output helpers use these `node.name`
+/// prefixes. They are not user-facing applications and should not be exposed
+/// as application volume controls.
+fn is_internal_output_stream(node_name: &str) -> bool {
+    node_name.starts_with("output.loopback-") || node_name.starts_with("output.combined_")
+}
+
 impl Node {
     /// Attains process info from a pipewire info node.
     #[must_use]
@@ -72,7 +81,6 @@ impl Node {
         let mut application_name = None;
         let mut application_binary = None;
         let mut application_icon_name = None;
-        let mut application_process_id: Option<u32> = None;
         let mut media_name = None;
 
         for (entry, value) in props.iter() {
@@ -121,10 +129,6 @@ impl Node {
                 // firefox, spotify (set on stream nodes)
                 "application.process.binary" => application_binary = Some(value.to_owned()),
 
-                // Present on streams created by a user application, but absent
-                // from PipeWire's own loopback and combined-output nodes.
-                "application.process.id" => application_process_id = value.parse().ok(),
-
                 // application-set icon name, preferred over icon-by-binary-name lookup
                 "application.icon-name" => application_icon_name = Some(value.to_owned()),
 
@@ -136,8 +140,11 @@ impl Node {
         }
 
         // Playback controls should enumerate user applications, not PipeWire's
-        // internal loopback or combined-output streams.
-        if matches!(media_class, Some(MediaClass::StreamOutput)) && application_process_id.is_none()
+        // internal loopback or combined-output streams. Some valid applications
+        // (for example, Wine/Proton games) do not set `application.process.id`,
+        // so identify internal nodes by their PipeWire node name instead.
+        if matches!(media_class, Some(MediaClass::StreamOutput))
+            && is_internal_output_stream(&node_name)
         {
             return None;
         }
@@ -176,6 +183,28 @@ impl Node {
         };
 
         Some(device)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_internal_output_stream;
+
+    #[test]
+    fn filters_pipewire_internal_output_streams() {
+        assert!(is_internal_output_stream("output.loopback-123-45"));
+        assert!(is_internal_output_stream(
+            "output.combined_input.loopback-123-45"
+        ));
+        assert!(is_internal_output_stream(
+            "output.combined_alsa_output.pci-0000_00_00.0"
+        ));
+    }
+
+    #[test]
+    fn keeps_application_output_streams() {
+        assert!(!is_internal_output_stream("ACBlackFlag.exe"));
+        assert!(!is_internal_output_stream("firefox"));
     }
 }
 


### PR DESCRIPTION
## Summary

Expose PipeWire application playback streams to audio clients. This adds application identity and icon metadata, distinguishes playback streams from devices, and filters PipeWire internal loopback/combined-output streams.

`NodeInfo.is_sink` is retained for compatibility with existing consumers such as cosmic-osd. The new optional `kind` field supplies the complete node classification; clients can safely fall back to `is_sink` when connected to an older daemon.

## Testing

- `cargo check -p cosmic-settings-audio-server -p cosmic-settings-audio-client`
- Verified against live PipeWire metadata with Cider and Zen playback streams.

- [x] I have disclosed use of AI-generated code in the commit message.
- [x] I understand these changes and can respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the Developer Certificate of Origin and certify my contribution under its conditions.