### PR TITLE
fix: panic on -1 max brightness value

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,10 @@ impl SettingsDaemon {
             let max = self.display_brightness_device.max_brightness();
             let min = self.display_brightness_device.min_brightness() as i32;
 
+            if min > max {
+                return;
+            }
+
             let clamped = value.clamp(min, max);
             _ = self
                 .display_brightness_device


### PR DESCRIPTION
Clamping can panic if the minimum value is greater than the max, so if there is an error that results in max being -1 we should do nothing.

Closes #175 

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

