### PR TITLE
Add fallback for missing theme v2 list_button

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -3,7 +3,7 @@
 // when the theme is set to auto-export color palette, write to gtk3 / gtk4 / kde / ... css files
 // read config file for lat/long
 
-use std::path::Path;
+use std::{fs, path::Path};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::bail;
@@ -32,6 +32,54 @@ pub enum ThemeMsg {
     /// true if dark
     Theme(bool),
     Tk(String),
+}
+
+fn ensure_theme_v2_list_button_fallback(theme_id: &str) {
+    let Some(config_root) = dirs::config_dir()
+        .map(|x| x.join("cosmic"))
+        .or_else(|| dirs::home_dir().map(|p| p.join(".config/cosmic")))
+    else {
+        return;
+    };
+
+    let local_theme_dir = config_root.join(theme_id).join("v2");
+    let local_list_button = local_theme_dir.join("list_button");
+    if local_list_button.exists() {
+        return;
+    }
+
+    let system_theme_dir = Path::new("/usr/share/cosmic").join(theme_id).join("v2");
+    let system_list_button = system_theme_dir.join("list_button");
+    if system_list_button.exists() {
+        return;
+    }
+
+    let local_button = local_theme_dir.join("button");
+    let system_button = system_theme_dir.join("button");
+    let source = if local_button.exists() {
+        local_button
+    } else if system_button.exists() {
+        system_button
+    } else {
+        log::warn!(
+            "Theme {theme_id} is missing v2/list_button and no compatible button fallback exists"
+        );
+        return;
+    };
+
+    if let Err(err) = fs::create_dir_all(&local_theme_dir) {
+        log::warn!(
+            "Failed to create theme fallback directory for {theme_id}: {err}"
+        );
+        return;
+    }
+
+    if let Err(err) = fs::copy(&source, &local_list_button) {
+        log::warn!(
+            "Failed to create v2/list_button fallback for {theme_id} from {}: {err}",
+            source.display()
+        );
+    }
 }
 
 impl SunriseSunset {
@@ -158,6 +206,9 @@ pub async fn watch_theme(
 
     set_gnome_button_layout(tk.show_maximize, tk.show_minimize);
     set_gnome_icon_theme(tk.icon_theme.clone());
+
+    ensure_theme_v2_list_button_fallback(cosmic_theme::DARK_THEME_ID);
+    ensure_theme_v2_list_button_fallback(cosmic_theme::LIGHT_THEME_ID);
 
     let light_helper = CosmicTheme::light_config()?;
     let dark_helper = CosmicTheme::dark_config()?;


### PR DESCRIPTION
  ## Summary

  Make `cosmic-settings-daemon` tolerate missing `v2/list_button` theme entries by creating a local fallback from `button` when needed.

  ## Problem

  On my system, `cosmic-settings-daemon` failed while loading the configured COSMIC theme because the installed theme data under `/usr/share/cosmic/.../v2/` did not include
  `list_button`.

  That caused theme loading errors during daemon startup, and the daemon was not able to stay healthy. Downstream clients that depend on its settings/audio varlink service, such
  as the audio applet and OSD, then failed to connect and showed broken audio state.

  ## Root Cause

  `Theme::get_entry(...)` expects the theme to provide `v2/list_button`, but some installed theme payloads only provide `v2/button`.

  This creates a hard failure in a place that should be recoverable.

  ## Change

  Before loading dark and light theme entries, the daemon now:

  - checks whether `v2/list_button` already exists
  - skips any change if it exists in user config or system theme data
  - if it is missing, looks for `v2/button`
  - creates a local fallback at `~/.config/cosmic/<theme-id>/v2/list_button`

  ## Why this approach

  - does not mutate `/usr/share/cosmic`
  - preserves user overrides
  - only applies when the key is actually missing
  - keeps `cosmic-settings-daemon` from failing on incomplete packaged theme data

  ## Validation

  Built successfully on August 5, 2026 with:

  ```bash
  cargo build
```
  I also reproduced the original failure locally and confirmed that providing the missing list_button fallback prevents the theme-loading crash path that breaks the settings/audio
  service chain.

  - [x] I have disclosed use of any AI generated code in my commit messages.
      - This patch was prepared with AI assistance, then manually reviewed, understood, and validated locally by me with cargo build on August 5, 2026.

  - [x] I understand these changes in full and will be able to respond to review comments.
  - [x] My change is accurately described in the commit message.
  - [x] My contribution is tested and working as described.
  - [x] I have read the Developer Certificate of Origin (https://developercertificate.org/) and certify my contribution under its conditions.