### PR TITLE
feat: handle playback specific sound settings

### DIFF
--- a/audio-client/src/lib.rs
+++ b/audio-client/src/lib.rs
@@ -145,4 +145,11 @@ pub trait CosmicAudioProxy {
         node_id: u32,
         balance: Option<f32>,
     ) -> zlink::Result<Result<Volume, Error>>;
+
+    /// Move a playback stream to an audio sink.
+    async fn set_playback_sink(
+        &mut self,
+        playback_id: u32,
+        sink_id: u32,
+    ) -> zlink::Result<Result<(), Error>>;
 }

--- a/audio-core/src/lib.rs
+++ b/audio-core/src/lib.rs
@@ -11,6 +11,8 @@ pub enum Error {
     ChannelSend,
     NoActiveSink,
     NoActiveSource,
+    InvalidPlayback,
+    InvalidSink,
 }
 
 impl std::fmt::Display for Error {
@@ -20,6 +22,8 @@ impl std::fmt::Display for Error {
             Error::ChannelSend => f.write_str("internal error: channel send failed"),
             Error::NoActiveSink => f.write_str("no active sink device to apply operation to"),
             Error::NoActiveSource => f.write_str("no active source to apply operation to"),
+            Error::InvalidPlayback => f.write_str("node is not an audio playback stream"),
+            Error::InvalidSink => f.write_str("node is not an audio sink"),
         }
     }
 }
@@ -102,6 +106,10 @@ pub enum Event {
     MonoAudio(bool),
     /// Add a node
     Node(u32, NodeInfo),
+    /// Add an audio playback stream.
+    Playback(u32, PlaybackInfo),
+    /// The sink explicitly targeted by a playback stream, or `None` to follow the default sink.
+    PlaybackTarget(u32, Option<u32>),
     /// Mute status of a node changed.
     NodeMute(u32, bool),
     /// Volume of a node changed.
@@ -150,7 +158,23 @@ impl From<EventV1> for Event {
 #[allow(deprecated)]
 impl From<Event> for EventV1 {
     fn from(event: Event) -> Self {
-        convert_event!(event, Event, EventV1)
+        match event {
+            Event::ActiveProfile(id, info) => Self::ActiveProfile(id, info),
+            Event::ActiveRoute(id, index, info) => Self::ActiveRoute(id, index, info),
+            Event::DefaultSink(id) => Self::DefaultSink(id),
+            Event::DefaultSource(id) => Self::DefaultSource(id),
+            Event::Device(id, info) => Self::Device(id, info),
+            Event::MonoAudio(enabled) => Self::MonoAudio(enabled),
+            Event::Node(id, info) => Self::Node(id, info),
+            Event::Playback(..) | Event::PlaybackTarget(..) => Self::Unknown,
+            Event::NodeMute(id, mute) => Self::NodeMute(id, mute),
+            Event::NodeVolume(id, volume, balance) => Self::NodeVolume(id, volume, balance),
+            Event::Profile(id, index, info) => Self::Profile(id, index, info),
+            Event::Route(id, index, info) => Self::Route(id, index, info),
+            Event::RemoveDevice(id) => Self::RemoveDevice(id),
+            Event::RemoveNode(id) => Self::RemoveNode(id),
+            Event::Unknown => Self::Unknown,
+        }
     }
 }
 
@@ -201,6 +225,15 @@ pub struct NodeInfo {
     pub device_id: Option<u32>,
     pub card_profile_device: Option<u32>,
     pub is_sink: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PlaybackInfo {
+    pub application_id: Option<String>,
+    pub application_name: Option<String>,
+    pub icon_name: Option<String>,
+    pub media_name: Option<String>,
+    pub node_name: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/audio-server/src/backend.rs
+++ b/audio-server/src/backend.rs
@@ -70,8 +70,19 @@ pub struct Model {
     pub node_volumes: IntMap<NodeId, (u32, Option<f32>)>,
     /// Node IDs for sinks
     sink_node_ids: Vec<NodeId>,
+    /// PipeWire object serials for sink nodes.
+    pub sink_node_serials: IntMap<NodeId, u64>,
     /// Node IDs for sources
     source_node_ids: Vec<NodeId>,
+
+    /** Playback stream information */
+
+    /// Information about playback streams shared with subscribed varlink clients.
+    pub playback_info: IntMap<NodeId, cosmic_settings_audio_core::PlaybackInfo>,
+    /// Raw PipeWire `target.object` values for playback streams.
+    playback_targets: IntMap<NodeId, String>,
+    /// Resolved sink node IDs for playback streams with explicit targets.
+    playback_sink_ids: IntMap<NodeId, NodeId>,
 
     /** Device object information */
 
@@ -176,7 +187,11 @@ impl Model {
             node_mute: Default::default(),
             node_volumes: Default::default(),
             sink_node_ids: Default::default(),
+            sink_node_serials: Default::default(),
             source_node_ids: Default::default(),
+            playback_info: Default::default(),
+            playback_targets: Default::default(),
+            playback_sink_ids: Default::default(),
             device_info: Default::default(),
             device_profiles: Default::default(),
             active_profiles: Default::default(),
@@ -457,6 +472,8 @@ impl Model {
 
                 let devices = self.device_info.clone();
                 let nodes = self.node_info.clone();
+                let playback = self.playback_info.clone();
+                let playback_sinks = self.playback_sink_ids.clone();
                 let profiles = self.device_profiles.clone();
                 let routes = self.device_routes.clone();
                 let active_profiles = self.active_profiles.clone();
@@ -512,6 +529,14 @@ impl Model {
                                 .into_iter()
                                 .map(|(node_id, node)| Event::Node(node_id, node)),
                         )
+                        .chain(
+                            playback
+                                .into_iter()
+                                .map(|(node_id, info)| Event::Playback(node_id, info)),
+                        )
+                        .chain(playback_sinks.into_iter().map(|(playback_id, sink_id)| {
+                            Event::PlaybackTarget(playback_id, Some(sink_id))
+                        }))
                         .chain(default_sink.into_iter().map(Event::DefaultSink))
                         .chain(default_source.into_iter().map(Event::DefaultSource))
                         .chain(
@@ -955,12 +980,16 @@ impl Model {
                     is_sink: matches!(node.media_class, pipewire::MediaClass::Sink),
                 };
 
-                self.emit_event(Event::Node(node.object_id, info.clone()))
-                    .await;
-
                 match node.media_class {
                     pipewire::MediaClass::Sink => {
                         self.sink_node_ids.push(node.object_id);
+                        self.sink_node_serials
+                            .insert(node.object_id, node.object_serial);
+
+                        let playback_ids = self.playback_targets.keys().collect::<Vec<_>>();
+                        for playback_id in playback_ids {
+                            self.refresh_playback_target(playback_id, false).await;
+                        }
 
                         // Set the sink as the default if it matches the server.
                         if self.active_sink_node_name == node.node_name {
@@ -998,11 +1027,39 @@ impl Model {
                             }
                         }
                     }
+
+                    pipewire::MediaClass::Playback => {
+                        let Some(playback) = node.playback else {
+                            tracing::warn!(
+                                target: "audio-backend",
+                                node_id = node.object_id,
+                                "playback node missing playback metadata"
+                            );
+                            return;
+                        };
+
+                        let info = cosmic_settings_audio_core::PlaybackInfo {
+                            application_id: playback.application_id,
+                            application_name: playback.application_name,
+                            icon_name: playback.icon_name,
+                            media_name: playback.media_name,
+                            node_name: node.node_name,
+                        };
+
+                        self.playback_info.insert(node.object_id, info.clone());
+                        self.emit_event(Event::Playback(node.object_id, info)).await;
+                        self.refresh_playback_target(node.object_id, true).await;
+                    }
                 }
 
-                self.node_info.insert(node.object_id, info.clone());
                 self.node_volumes.entry(node.object_id).or_insert((0, None));
                 self.node_mute.entry(node.object_id).or_insert(true);
+
+                // Playback streams have their own dedicated event.
+                if !matches!(node.media_class, pipewire::MediaClass::Playback) {
+                    self.node_info.insert(node.object_id, info.clone());
+                    self.emit_event(Event::Node(node.object_id, info)).await;
+                }
             }
 
             pipewire::Event::MonoAudio(enabled) => {
@@ -1023,6 +1080,18 @@ impl Model {
                         .status()
                         .await;
                 });
+            }
+
+            pipewire::Event::PlaybackTarget(id, target) => {
+                match target {
+                    Some(target) => {
+                        self.playback_targets.insert(id, target);
+                    }
+                    None => {
+                        self.playback_targets.remove(id);
+                    }
+                }
+                self.refresh_playback_target(id, true).await;
             }
 
             pipewire::Event::DefaultSink(node_name) => {
@@ -1072,6 +1141,39 @@ impl Model {
         })
     }
 
+    async fn refresh_playback_target(&mut self, playback_id: NodeId, force: bool) {
+        if !self.playback_info.contains_key(playback_id) {
+            return;
+        }
+
+        let sink_id = self.playback_targets.get(playback_id).and_then(|target| {
+            if let Ok(serial) = target.parse::<u64>() {
+                self.sink_node_serials
+                    .iter()
+                    .find_map(|(id, value)| (*value == serial).then_some(id))
+            } else {
+                self.node_info
+                    .iter()
+                    .find_map(|(id, node)| (node.is_sink && node.name == *target).then_some(id))
+            }
+        });
+        let previous = self.playback_sink_ids.get(playback_id).copied();
+
+        match sink_id {
+            Some(sink_id) => {
+                self.playback_sink_ids.insert(playback_id, sink_id);
+            }
+            None => {
+                self.playback_sink_ids.remove(playback_id);
+            }
+        }
+
+        if force || previous != sink_id {
+            self.emit_event(Event::PlaybackTarget(playback_id, sink_id))
+                .await;
+        }
+    }
+
     async fn remove_device(&mut self, id: DeviceId) {
         tracing::debug!(target: "audio-backend", "Device {id} removed");
         _ = self.device_headset_check.remove(id);
@@ -1105,6 +1207,19 @@ impl Model {
         }
 
         _ = self.node_info.remove(id);
+        _ = self.playback_info.remove(id);
+        _ = self.playback_targets.remove(id);
+        _ = self.playback_sink_ids.remove(id);
+        _ = self.sink_node_serials.remove(id);
+
+        let affected_playback = self
+            .playback_sink_ids
+            .iter()
+            .filter_map(|(playback_id, sink_id)| (*sink_id == id).then_some(playback_id))
+            .collect::<Vec<_>>();
+        for playback_id in affected_playback {
+            self.refresh_playback_target(playback_id, false).await;
+        }
         _ = self.node_devices.remove(id);
         _ = self.node_mute.remove(id);
 

--- a/audio-server/src/server.rs
+++ b/audio-server/src/server.rs
@@ -276,6 +276,27 @@ impl Server {
         let (volume, balance) = *entry;
         set_node_volume(&mut model, node_id, volume, balance)
     }
+
+    /// Move a playback stream to a sink using WirePlumber's linking metadata.
+    pub async fn set_playback_sink(&mut self, playback_id: u32, sink_id: u32) -> Result<(), Error> {
+        let model = self.backend.model.lock().await;
+        if !model.playback_info.contains_key(playback_id) {
+            return Err(Error::InvalidPlayback);
+        }
+        let sink_serial = model
+            .sink_node_serials
+            .get(sink_id)
+            .ok_or(Error::InvalidSink)?;
+
+        model.pipewire_send(cosmic_pipewire::Request::SetMetadataProperty {
+            name: "default".to_owned(),
+            subject: playback_id,
+            key: "target.object".to_owned(),
+            type_: Some("Spa:Id".to_owned()),
+            value: Some(sink_serial.to_string()),
+        });
+        Ok(())
+    }
 }
 
 fn set_node_mute(

--- a/cosmic-pipewire/src/lib.rs
+++ b/cosmic-pipewire/src/lib.rs
@@ -8,7 +8,7 @@ pub use device::Device;
 
 pub mod node;
 use intmap::IntMap;
-pub use node::{MediaClass, Node, NodeProps};
+pub use node::{MediaClass, Node, NodeProps, PlaybackInfo};
 
 mod profile;
 pub use profile::{Profile, ProfileClass};
@@ -393,13 +393,16 @@ where
         "default" => listener
             .property({
                 let state = Rc::downgrade(&state);
-                move |_subject, key, _type, value| {
-                    let Some((key, value)) = key.zip(value) else {
+                move |subject, key, _type, value| {
+                    let Some(key) = key else {
                         return 0;
                     };
 
                     match key {
                         "default.audio.sink" => {
+                            let Some(value) = value else {
+                                return 0;
+                            };
                             tracing::info!(target:"audio-backend", value, "default.audio.sink");
                             if let Ok(value) = serde_json::de::from_str::<DefaultAudio>(value)
                                 && let Some(state) = state.upgrade()
@@ -409,11 +412,22 @@ where
                         }
 
                         "default.audio.source" => {
+                            let Some(value) = value else {
+                                return 0;
+                            };
                             tracing::info!(target:"audio-backend", value, "default.audio.source");
                             if let Ok(value) = serde_json::de::from_str::<DefaultAudio>(value)
                                 && let Some(state) = state.upgrade()
                             {
                                 state.borrow_mut().default_source(value.name.to_owned())
+                            }
+                        }
+
+                        "target.object" => {
+                            if let Some(state) = state.upgrade() {
+                                state
+                                    .borrow_mut()
+                                    .playback_target(subject, value.map(ToOwned::to_owned));
                             }
                         }
 
@@ -494,6 +508,8 @@ pub enum Event {
     DefaultSource(String),
     /// Mono audio node setting changed.
     MonoAudio(bool),
+    /// A playback stream's explicit target object changed.
+    PlaybackTarget(NodeId, Option<String>),
     /// Emitted when the properties of a node has changed.
     NodeProperties(NodeId, NodeProps),
     /// A device with the given device_id was removed.
@@ -717,6 +733,10 @@ impl State {
 
     fn mono_audio(&mut self, enabled: bool) {
         self.on_event(Event::MonoAudio(enabled))
+    }
+
+    fn playback_target(&mut self, id: NodeId, target: Option<String>) {
+        self.on_event(Event::PlaybackTarget(id, target))
     }
 
     fn on_event(&mut self, event: Event) {

--- a/cosmic-pipewire/src/node.rs
+++ b/cosmic-pipewire/src/node.rs
@@ -14,6 +14,7 @@ use std::ffi::c_float;
 #[derive(Clone, Debug)]
 pub struct Node {
     pub object_id: u32,
+    pub object_serial: u64,
     pub audio_channels: u32,
     pub audio_position: String,
     pub card_profile_device: Option<u32>,
@@ -24,7 +25,16 @@ pub struct Node {
     pub icon_name: String,
     pub media_class: MediaClass,
     pub node_name: String,
+    pub playback: Option<PlaybackInfo>,
     pub state: State,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlaybackInfo {
+    pub application_id: Option<String>,
+    pub application_name: Option<String>,
+    pub icon_name: Option<String>,
+    pub media_name: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -40,6 +50,7 @@ pub enum State {
 pub enum MediaClass {
     Source,
     Sink,
+    Playback,
 }
 
 impl Node {
@@ -50,26 +61,35 @@ impl Node {
 
         let mut audio_channels = 1;
         let mut audio_position = String::new();
+        let mut application_id = None;
+        let mut application_name = None;
+        let mut application_icon_name = None;
         let mut card_profile_device = None;
         let mut device_id = None;
         let mut device_profile_description: &str = "";
         let mut device_profile_pro = false;
         let mut icon_name = String::new();
         let mut media_class = None;
+        let mut media_name = None;
         let mut node_description: &str = "";
         let mut node_name = String::new();
         let mut object_id = None;
+        let mut object_serial = None;
 
         for (entry, value) in props.iter() {
             match entry {
                 "device.id" => device_id = value.parse::<u32>().ok(),
                 "object.id" => object_id = Some(value.parse::<u32>().ok()?),
+                "object.serial" => object_serial = Some(value.parse::<u64>().ok()?),
 
                 // 2
                 "audio.channels" => audio_channels = value.parse::<u32>().unwrap_or(1),
 
                 // FL,FR
                 "audio.position" => audio_position = value.to_owned(),
+                "application.id" => application_id = Some(value.to_owned()),
+                "application.name" => application_name = Some(value.to_owned()),
+                "application.icon-name" => application_icon_name = Some(value.to_owned()),
 
                 // 0
                 "card.profile.device" => card_profile_device = Some(value.parse::<u32>().ok()?),
@@ -89,9 +109,11 @@ impl Node {
                     media_class = Some(match value {
                         "Audio/Sink" => MediaClass::Sink,
                         "Audio/Source" => MediaClass::Source,
+                        "Stream/Output/Audio" => MediaClass::Playback,
                         _ => return None,
                     })
                 }
+                "media.name" => media_name = Some(value.to_owned()),
 
                 // alsa_input.pci-0000_66_00.6.analog-stereo
                 "node.name" => node_name = value.to_owned(),
@@ -103,11 +125,20 @@ impl Node {
             }
         }
 
+        let media_class = media_class?;
+        let playback = matches!(media_class, MediaClass::Playback).then_some(PlaybackInfo {
+            application_id,
+            application_name,
+            icon_name: application_icon_name,
+            media_name,
+        });
+
         let device = Node {
             object_id: object_id?,
+            object_serial: object_serial?,
             device_id,
             card_profile_device,
-            media_class: media_class?,
+            media_class,
             description: if device_profile_description.is_empty() {
                 node_description.to_owned()
             } else {
@@ -123,6 +154,7 @@ impl Node {
             audio_channels,
             audio_position,
             node_name,
+            playback,
             state: match info.state() {
                 NodeState::Idle => State::Idle,
                 NodeState::Running => State::Running,

--- a/varlink-server/src/lib.rs
+++ b/varlink-server/src/lib.rs
@@ -324,6 +324,23 @@ where
             .set_node_volume_balance(node_id, balance)
             .await
     }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Audio",
+        rename = "SetPlaybackSink"
+    )]
+    pub async fn audio_set_playback_sink(
+        &mut self,
+        playback_id: u32,
+        sink_id: u32,
+    ) -> Result<(), audio::Error> {
+        self.0
+            .lock()
+            .await
+            .audio_server
+            .set_playback_sink(playback_id, sink_id)
+            .await
+    }
 }
 
 pub struct DaemonInner {


### PR DESCRIPTION
This PR adds support for application specific audio playback settings:
- Tracks individual playback streams and their metadata (application, icon, media, etc.)
- Tracks which audio sink each playback stream targets
- Adds an API to change the sink of a playback stream
- Emits `Playback` event whenever a playback stream is added or changed

Depends On:
- [x] https://github.com/pop-os/cosmic-settings-daemon/pull/181

Preparation for:
- https://github.com/pop-os/cosmic-settings/pull/2138

---
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

