### PR TITLE
fix(battery): watch AC plug events from line power device via upower

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "acpid_plug"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4749b4cc0bc6e487b73236a5b77e0cfe33122f4516f94fea48479dd66b17b4b0"
-dependencies = [
- "futures-util",
- "tokio",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,7 +982,6 @@ dependencies = [
 name = "cosmic-settings-daemon"
 version = "0.1.0"
 dependencies = [
- "acpid_plug",
  "anyhow",
  "calloop",
  "calloop-wayland-source",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ default-features = false
 features = ["tokio"]
 
 [dependencies]
-acpid_plug = "0.1.2"
 anyhow = "1.0.99"
 chrono = "0.4.42"
 cosmic-comp-config = { git = "https://github.com/pop-os/cosmic-comp" }

--- a/src/battery.rs
+++ b/src/battery.rs
@@ -1,57 +1,96 @@
-use acpid_plug::AcPlugEvents;
+use futures::FutureExt;
 use notify_rust::Notification;
 use std::path::Path;
+use std::pin::Pin;
 use std::time::{Duration, Instant};
+use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::error::TryRecvError;
-use tokio::sync::mpsc::{Receiver, Sender};
 use tokio_stream::StreamExt;
-use upower_dbus::BatteryLevel;
-use zbus::Connection;
+use upower_dbus::{BatteryLevel, UPowerProxy};
+
+pub type OnBatteryFn = Box<dyn Fn(bool) -> Pin<Box<dyn Future<Output = bool>>>>;
 
 // TODO: Add config parameter for changing the preferred sound theme.
 
-pub async fn monitor() {
-    let Ok(ac_plug_events) = acpid_plug::connect().await else {
-        return;
+/// If a battery is detected, begin watching for on_battery events from upower.
+async fn watch_battery_plug_events(
+    conn: &zbus::Connection,
+    upower: &UPowerProxy<'static>,
+) -> (bool, OnBatteryFn) {
+    let mut line_power_device = None;
+    let line_power_device_path = match upower.enumerate_devices().await {
+        Ok(devices) => devices.into_iter().find(|device_path| {
+            device_path
+                .rsplit_once('/')
+                .is_some_and(|(_, name)| name.starts_with("line_power"))
+        }),
+        _ => None,
     };
 
-    let ac_plugged = ac_plug_events.plugged();
-    let (ac_plug_tx, ac_plug_rx) = tokio::sync::mpsc::channel(1);
-    tokio::task::spawn_local(ac_plug_monitor(ac_plug_events, ac_plug_tx));
-    low_power_monitor(ac_plugged, ac_plug_rx).await;
-}
+    if let Some(path) = line_power_device_path
+        && let Ok(device) = upower_dbus::DeviceProxy::new(conn, path).await
+        && let Ok(online) = device.online().await
+    {
+        line_power_device = Some((device, !online))
+    }
 
-/// Watch AC plug events and emit sounds on plug event changes.
-pub async fn ac_plug_monitor(
-    mut ac_plug_events: AcPlugEvents,
-    ac_plug_tx: Sender<acpid_plug::Event>,
-) {
-    if let Some(Ok(event)) = ac_plug_events.next().await {
-        let _res = ac_plug_tx.send(event).await;
+    match line_power_device {
+        Some((device, is_on_battery)) => {
+            let mut on_battery_plugged_stream = device.receive_online_changed().await;
+            let (battery_plugged_tx, battery_plugged_rx) =
+                tokio::sync::watch::channel(is_on_battery);
+            tokio::task::spawn_local(async move {
+                let mut debounce_task: Option<tokio::task::JoinHandle<bool>> = None;
+                loop {
+                    let Some(property) = on_battery_plugged_stream.next().await else {
+                        continue;
+                    };
 
-        // Use a tokio watch channel to debounce the ac plug events.
-        let (tx, mut rx) = tokio::sync::watch::channel(event);
+                    let Ok(is_online) = property.get().await else {
+                        continue;
+                    };
 
-        tokio::task::spawn_local(async move {
-            while let Some(Ok(event)) = ac_plug_events.next().await {
-                if tx.send(event).is_err() {
-                    break;
+                    // Cancel pending message-sending task if it is still waiting.
+                    if let Some(task) = debounce_task.take() {
+                        task.abort();
+
+                        // Break from this task if there was an error sending a message.
+                        if let Ok(true) = task.await {
+                            break;
+                        }
+                    }
+
+                    // Delay message-sending with a task that waits 500ms before sending.
+                    let battery_plugged_tx = battery_plugged_tx.clone();
+                    debounce_task = Some(tokio::task::spawn_local(async move {
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                        battery_plugged_tx.send(!is_online).is_err()
+                    }));
+
+                    continue;
                 }
-            }
-        });
+            });
 
-        // Listen for changes to the AC plug state.
-        while let Ok(()) = rx.changed().await {
-            let _res = ac_plug_tx.send(*rx.borrow_and_update()).await;
+            let watch_fn: OnBatteryFn = Box::new(move |on_battery: bool| {
+                let mut battery_plugged_rx = battery_plugged_rx.clone();
+                Box::pin(async move {
+                    _ = battery_plugged_rx.wait_for(|&v| v != on_battery).await;
+                    *battery_plugged_rx.borrow_and_update()
+                })
+            });
 
-            // Wait at least 500 ms before checking for another change.
-            tokio::time::sleep(Duration::from_millis(500)).await;
+            (is_on_battery, watch_fn)
         }
+
+        None => (
+            false,
+            Box::new(|_on_battery: bool| futures::future::pending::<bool>().boxed()),
+        ),
     }
 }
 
-pub async fn low_power_monitor(mut ac_plugged: bool, mut ac_plug_rx: Receiver<acpid_plug::Event>) {
-    let Ok(conn) = Connection::system().await else {
+pub async fn low_power_monitor() {
+    let Some(conn) = crate::utils::zbus_system_connection().await else {
         return;
     };
 
@@ -67,24 +106,19 @@ pub async fn low_power_monitor(mut ac_plugged: bool, mut ac_plug_rx: Receiver<ac
     let mut last_critical_notification = Instant::now();
     let mut last_low_notification = last_critical_notification;
     let mut percent_changed_stream = device.receive_percentage_changed().await;
+    let (mut is_on_battery, battery_plug_watch) = watch_battery_plug_events(&conn, &upower).await;
 
     let (nag_tx, nag_rx) = tokio::sync::mpsc::channel(1);
-
     tokio::task::spawn_local(critical_battery_nag(nag_rx));
 
     loop {
         tokio::select! {
-            event = ac_plug_rx.recv() => {
-                let Some(event) = event else {
-                    break
-                };
-
-                ac_plugged = event == acpid_plug::Event::Plugged;
-
-                on_ac_plug(event, current_battery);
+            _ = battery_plug_watch(is_on_battery) => {
+                is_on_battery = !is_on_battery;
+                on_ac_plug(!is_on_battery, current_battery);
 
                 if BatteryLevel::Critical == current_battery {
-                    let _res = nag_tx.send(!ac_plugged).await;
+                    let _res = nag_tx.send(is_on_battery).await;
                 }
             },
 
@@ -101,7 +135,7 @@ pub async fn low_power_monitor(mut ac_plugged: bool, mut ac_plug_rx: Receiver<ac
                             }
 
                             current_battery = BatteryLevel::Critical;
-                            let _res = nag_tx.send(!ac_plugged).await;
+                            let _res = nag_tx.send(is_on_battery).await;
 
                             let now = Instant::now();
                             if now.duration_since(last_critical_notification) > Duration::from_secs(30) {
@@ -139,7 +173,6 @@ pub async fn low_power_monitor(mut ac_plugged: bool, mut ac_plug_rx: Receiver<ac
                                     .show_async()
                                     .await;
                             }
-
                         }
 
                         100.0 => {
@@ -186,8 +219,8 @@ async fn critical_battery_nag(mut watch: Receiver<bool>) {
 }
 
 /// Play a power plug sound on an AC plug event.
-fn on_ac_plug(event: acpid_plug::Event, battery_level: BatteryLevel) {
-    let (theme, sound) = if matches!(event, acpid_plug::Event::Plugged) {
+fn on_ac_plug(is_plugged: bool, battery_level: BatteryLevel) {
+    let (theme, sound) = if is_plugged {
         ("freedesktop", "power-plug")
     } else if Path::new("/usr/share/sounds/Pop/").exists()
         && matches!(battery_level, BatteryLevel::Low | BatteryLevel::Critical)

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ mod logind_session;
 mod pipewire;
 mod theme;
 mod time;
+mod utils;
 mod wayland;
 
 // Use seperate HasDisplayBrightness, or -1?
@@ -55,9 +56,11 @@ struct SettingsDaemon {
     logind_session: Option<LogindSessionProxy<'static>>,
     a11y_session: Option<Mutex<cosmic_dbus_a11y::StatusProxy<'static>>>,
     display_brightness_device: BrightnessDevice,
+    #[allow(clippy::type_complexity)]
     watched_configs: Arc<
         RwLock<HashMap<(String, u64), (Connection, ObjectPath<'static>, WellKnownName<'static>)>>,
     >,
+    #[allow(clippy::type_complexity)]
     watched_states: Arc<
         RwLock<HashMap<(String, u64), (Connection, ObjectPath<'static>, WellKnownName<'static>)>>,
     >,

--- a/src/main.rs
+++ b/src/main.rs
@@ -630,7 +630,7 @@ async fn main() -> ExitCode {
                 backlight_monitor_task(backlights, conn_clone).await;
             });
 
-            tokio::task::spawn_local(battery::monitor());
+            tokio::task::spawn_local(battery::low_power_monitor());
 
             let conn_clone = connection.clone();
             task::spawn_local(async move {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,17 @@
+// Copyright 2026 System76 <info@system76.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::sync::OnceLock;
+
+/// Globally-shared dbus system connection.
+pub async fn zbus_system_connection() -> Option<zbus::Connection> {
+    static CONNECTION: OnceLock<zbus::Connection> = OnceLock::new();
+
+    if let Some(conn) = CONNECTION.get() {
+        return Some(conn.clone());
+    }
+
+    let conn = zbus::Connection::system().await.ok()?;
+    _ = CONNECTION.set(conn.clone());
+    Some(conn)
+}


### PR DESCRIPTION
Use upower to listen for AC plug events via the first `line_power` device that it finds (ie: `line_power_ADP0`).

Closes #176 

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

