### PR TITLE
refactor(audio): make events backward compatible

### DIFF
--- a/audio-client/src/codec.rs
+++ b/audio-client/src/codec.rs
@@ -1,10 +1,26 @@
 // Copyright 2026 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
-use cosmic_settings_audio_core::Event;
+#![allow(deprecated)]
+
+use cosmic_settings_audio_core::{Event, EventV1};
 use tokio_util::bytes::Buf;
 
 const MAX: usize = 8 * 1024 * 1024;
+
+pub struct EventV1Decoder;
+
+impl tokio_util::codec::Decoder for EventV1Decoder {
+    type Item = EventV1;
+    type Error = Error;
+
+    fn decode(
+        &mut self,
+        src: &mut tokio_util::bytes::BytesMut,
+    ) -> Result<Option<Self::Item>, Self::Error> {
+        decode(src)
+    }
+}
 
 pub struct EventDecoder;
 
@@ -16,44 +32,50 @@ impl tokio_util::codec::Decoder for EventDecoder {
         &mut self,
         src: &mut tokio_util::bytes::BytesMut,
     ) -> Result<Option<Self::Item>, Self::Error> {
-        if src.len() < 4 {
-            // Not enough data to read length marker.
-            return Ok(None);
-        }
-
-        // Read length marker.
-        let mut length_bytes = [0u8; 4];
-        length_bytes.copy_from_slice(&src[..4]);
-        let length = u32::from_le_bytes(length_bytes) as usize;
-
-        // Check that the length is not too large to avoid a denial of
-        // service attack where the server runs out of memory.
-        if length > MAX {
-            return Err(Error::IO(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("Frame of length {} is too large.", length),
-            )));
-        }
-
-        if src.len() < 4 + length {
-            // The full string has not yet arrived.
-            //
-            // We reserve more space in the buffer. This is not strictly
-            // necessary, but is a good idea performance-wise.
-            src.reserve(4 + length - src.len());
-
-            // We inform the Framed that we need more bytes to form the next
-            // frame.
-            return Ok(None);
-        }
-
-        // Use advance to modify src such that it no longer contains
-        // this frame.
-        let data = src[4..4 + length].to_vec();
-        src.advance(4 + length);
-
-        ron::de::from_bytes(&data).map(Some).map_err(Error::Ron)
+        decode(src)
     }
+}
+
+fn decode<T: serde::de::DeserializeOwned>(
+    src: &mut tokio_util::bytes::BytesMut,
+) -> Result<Option<T>, Error> {
+    if src.len() < 4 {
+        // Not enough data to read length marker.
+        return Ok(None);
+    }
+
+    // Read length marker.
+    let mut length_bytes = [0u8; 4];
+    length_bytes.copy_from_slice(&src[..4]);
+    let length = u32::from_le_bytes(length_bytes) as usize;
+
+    // Check that the length is not too large to avoid a denial of
+    // service attack where the server runs out of memory.
+    if length > MAX {
+        return Err(Error::IO(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Frame of length {} is too large.", length),
+        )));
+    }
+
+    if src.len() < 4 + length {
+        // The full string has not yet arrived.
+        //
+        // We reserve more space in the buffer. This is not strictly
+        // necessary, but is a good idea performance-wise.
+        src.reserve(4 + length - src.len());
+
+        // We inform the Framed that we need more bytes to form the next
+        // frame.
+        return Ok(None);
+    }
+
+    // Use advance to modify src such that it no longer contains
+    // this frame.
+    let data = src[4..4 + length].to_vec();
+    src.advance(4 + length);
+
+    ron::de::from_bytes(&data).map(Some).map_err(Error::Ron)
 }
 
 #[derive(Debug)]

--- a/audio-client/src/lib.rs
+++ b/audio-client/src/lib.rs
@@ -32,16 +32,30 @@ impl Client {
             Error,
         >,
     > {
-        self.conn
-            .recv_events()
-            .await
-            .map(|(result, mut fds)| match result {
-                Ok(()) => Ok(tokio_util::codec::FramedRead::new(
-                    tokio::net::unix::pipe::Receiver::from_owned_fd(fds.swap_remove(0)).unwrap(),
-                    codec::EventDecoder,
-                )),
-                Err(why) => Err(why),
-            })
+        use futures_util::{StreamExt, future::Either};
+
+        match self.conn.recv_events_v2().await {
+            Ok((Ok(()), mut fds)) => Ok(Ok(Either::Left(tokio_util::codec::FramedRead::new(
+                tokio::net::unix::pipe::Receiver::from_owned_fd(fds.swap_remove(0)).unwrap(),
+                codec::EventDecoder,
+            )))),
+            Ok((Err(why), _)) => Ok(Err(why)),
+            Err(_) => self
+                .conn
+                .recv_events()
+                .await
+                .map(|(result, mut fds)| match result {
+                    Ok(()) => Ok(Either::Right(
+                        tokio_util::codec::FramedRead::new(
+                            tokio::net::unix::pipe::Receiver::from_owned_fd(fds.swap_remove(0))
+                                .unwrap(),
+                            codec::EventV1Decoder,
+                        )
+                        .map(|result| result.map(Event::from)),
+                    )),
+                    Err(why) => Err(why),
+                }),
+        }
     }
 }
 
@@ -56,6 +70,10 @@ pub trait CosmicAudioProxy {
     /// Request to listen to audio events through the returned `OwnedFd`.
     #[zlink(return_fds)]
     async fn recv_events(&mut self) -> zlink::Result<(Result<(), Error>, Vec<OwnedFd>)>;
+
+    /// Request to listen to v2 audio events through the returned `OwnedFd`.
+    #[zlink(return_fds)]
+    async fn recv_events_v2(&mut self) -> zlink::Result<(Result<(), Error>, Vec<OwnedFd>)>;
 
     async fn default_sink(&mut self) -> zlink::Result<Result<Node, Error>>;
 

--- a/audio-core/src/lib.rs
+++ b/audio-core/src/lib.rs
@@ -52,6 +52,41 @@ pub struct Volume {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[deprecated(note = "use Event with the v2 event subscription instead")]
+pub enum EventV1 {
+    /// The active profile of a device may have changed
+    ActiveProfile(u32, ProfileInfo),
+    /// The active route of a device may have changed
+    ActiveRoute(u32, u32, RouteInfo),
+    /// Default sink change
+    DefaultSink(u32),
+    /// Default source change
+    DefaultSource(u32),
+    /// Add a device
+    Device(u32, DeviceInfo),
+    /// Mono audio state has changed.
+    MonoAudio(bool),
+    /// Add a node
+    Node(u32, NodeInfo),
+    /// Mute status of a node changed.
+    NodeMute(u32, bool),
+    /// Volume of a node changed.
+    NodeVolume(u32, u32, Option<f32>),
+    /// A profile on a device may have changed
+    Profile(u32, u32, ProfileInfo),
+    /// A route on a device may have changed
+    Route(u32, u32, RouteInfo),
+    /// Remove a device.
+    RemoveDevice(u32),
+    /// Remove a node.
+    RemoveNode(u32),
+    /// Serde will fallback to this if a new enum variant was added that is unknown to the client
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "t", content = "v")]
 pub enum Event {
     /// The active profile of a device may have changed
     ActiveProfile(u32, ProfileInfo),
@@ -82,6 +117,41 @@ pub enum Event {
     /// Serde will fallback to this if a new enum variant was added that is unknown to the client
     #[serde(other)]
     Unknown,
+}
+
+macro_rules! convert_event {
+    ($event:expr, $source:ident, $target:ident) => {
+        match $event {
+            $source::ActiveProfile(id, info) => $target::ActiveProfile(id, info),
+            $source::ActiveRoute(id, index, info) => $target::ActiveRoute(id, index, info),
+            $source::DefaultSink(id) => $target::DefaultSink(id),
+            $source::DefaultSource(id) => $target::DefaultSource(id),
+            $source::Device(id, info) => $target::Device(id, info),
+            $source::MonoAudio(enabled) => $target::MonoAudio(enabled),
+            $source::Node(id, info) => $target::Node(id, info),
+            $source::NodeMute(id, mute) => $target::NodeMute(id, mute),
+            $source::NodeVolume(id, volume, balance) => $target::NodeVolume(id, volume, balance),
+            $source::Profile(id, index, info) => $target::Profile(id, index, info),
+            $source::Route(id, index, info) => $target::Route(id, index, info),
+            $source::RemoveDevice(id) => $target::RemoveDevice(id),
+            $source::RemoveNode(id) => $target::RemoveNode(id),
+            $source::Unknown => $target::Unknown,
+        }
+    };
+}
+
+#[allow(deprecated)]
+impl From<EventV1> for Event {
+    fn from(event: EventV1) -> Self {
+        convert_event!(event, EventV1, Event)
+    }
+}
+
+#[allow(deprecated)]
+impl From<Event> for EventV1 {
+    fn from(event: Event) -> Self {
+        convert_event!(event, Event, EventV1)
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -162,4 +232,31 @@ pub enum Availability {
     #[default]
     #[serde(other)]
     Unknown,
+}
+
+#[cfg(test)]
+#[allow(deprecated)]
+mod tests {
+    use super::{Event, EventV1};
+
+    #[test]
+    fn event_wire_formats_are_versioned() {
+        assert_eq!(
+            ron::to_string(&EventV1::DefaultSink(42)).unwrap(),
+            "DefaultSink(42)"
+        );
+        assert_eq!(
+            ron::to_string(&Event::DefaultSink(42)).unwrap(),
+            "(t:DefaultSink,v:42)"
+        );
+    }
+
+    #[test]
+    fn events_convert_between_versions() {
+        let v2 = Event::from(EventV1::NodeVolume(42, 75, Some(0.25)));
+        let Event::NodeVolume(id, volume, balance) = v2 else {
+            panic!("unexpected event variant");
+        };
+        assert_eq!((id, volume, balance), (42, 75, Some(0.25)));
+    }
 }

--- a/audio-server/src/backend.rs
+++ b/audio-server/src/backend.rs
@@ -1,9 +1,11 @@
 // Copyright 2024 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
+#![allow(deprecated)]
+
 use cosmic_config::ConfigSet;
 use cosmic_pipewire::{self as pipewire, Direction, NodeProps, PortType, ProfileClass};
-use cosmic_settings_audio_core::Event;
+use cosmic_settings_audio_core::{Event, EventV1};
 use cosmic_settings_daemon_config::{CosmicSettingsDaemonConfig, CosmicSettingsDaemonState};
 use futures_util::{SinkExt, StreamExt};
 use intmap::IntMap;
@@ -46,6 +48,8 @@ pub struct HeadsetProfile {
 pub struct Model {
     /// Varlink clients that are actively listening for events through Unix pipes.
     subscribers: Arc<tokio::sync::Mutex<Vec<pipe::Sender>>>,
+    /// Varlink clients listening for v2 events.
+    subscribers_v2: Arc<tokio::sync::Mutex<Vec<pipe::Sender>>>,
 
     /// The sending half of a channel for sending requests to cosmic-pipewire.
     pipewire_sender: Option<pipewire::Sender>,
@@ -117,6 +121,35 @@ pub struct Model {
     pub source_mute: bool,
 }
 
+async fn emit_serialized(
+    subscribers: Arc<tokio::sync::Mutex<Vec<pipe::Sender>>>,
+    serialized: String,
+) {
+    let mut subscribers_guard = subscribers.lock().await;
+    let subscribers: Vec<pipe::Sender> = std::mem::take(&mut subscribers_guard);
+    *subscribers_guard = subscribers
+        .into_iter()
+        .map(move |subscriber| {
+            let serialized = serialized.clone();
+            async move {
+                let mut writer = FramedWrite::new(subscriber, crate::codec::EventCodec);
+                if writer.send(serialized.as_bytes()).await.is_ok() {
+                    Some(writer.into_inner())
+                } else {
+                    None
+                }
+            }
+        })
+        .collect::<futures_util::stream::FuturesUnordered<_>>()
+        .fold(Vec::new(), |mut retained, result| async move {
+            if let Some(subscriber) = result {
+                retained.push(subscriber);
+            }
+            retained
+        })
+        .await;
+}
+
 impl Model {
     pub async fn new() -> Self {
         // Create if missing before creating a cosmic-config context.
@@ -136,6 +169,7 @@ impl Model {
             daemon_config_context,
             daemon_state_context,
             subscribers: Default::default(),
+            subscribers_v2: Default::default(),
             pipewire_sender: Default::default(),
             node_devices: Default::default(),
             node_info: Default::default(),
@@ -174,35 +208,17 @@ impl Model {
     /// Send events to subscribed clients.
     pub async fn emit_event(&self, event: Event) {
         let subscribers = self.subscribers.clone();
+        let subscribers_v2 = self.subscribers_v2.clone();
         _ = tokio::task::spawn_local(async move {
-            let Ok(serialized) = ron::ser::to_string(&event) else {
-                return;
-            };
+            let serialized_v1 = ron::ser::to_string(&EventV1::from(event.clone()));
+            let serialized_v2 = ron::ser::to_string(&event);
 
-            let serialized_bytes = serialized.as_bytes();
-
-            // Concurrently write event to subscribers and discard those who fail.
-            let mut subscribers_guard = subscribers.lock().await;
-            let subscribers: Vec<pipe::Sender> = std::mem::take(&mut subscribers_guard);
-            *subscribers_guard = subscribers
-                .into_iter()
-                .map(move |subscriber| async move {
-                    let mut writer = FramedWrite::new(subscriber, crate::codec::EventCodec);
-                    if writer.send(serialized_bytes).await.is_ok() {
-                        Some(writer.into_inner())
-                    } else {
-                        None
-                    }
-                })
-                .collect::<futures_util::stream::FuturesUnordered<_>>()
-                .fold(Vec::new(), |mut retained, result| async move {
-                    if let Some(subscriber) = result {
-                        retained.push(subscriber);
-                    }
-
-                    retained
-                })
-                .await;
+            if let Ok(serialized) = serialized_v1 {
+                emit_serialized(subscribers, serialized).await;
+            }
+            if let Ok(serialized) = serialized_v2 {
+                emit_serialized(subscribers_v2, serialized).await;
+            }
         })
         .await;
     }
@@ -425,10 +441,19 @@ impl Model {
                 }
             }
 
-            Message::Subscribe(socket_path) => {
-                tracing::debug!(target: "audio-backend", "subscribing client");
+            message @ (Message::Subscribe(_) | Message::SubscribeV2(_)) => {
+                let (socket_path, v2) = match message {
+                    Message::Subscribe(socket_path) => (socket_path, false),
+                    Message::SubscribeV2(socket_path) => (socket_path, true),
+                    _ => unreachable!(),
+                };
+                tracing::debug!(target: "audio-backend", v2, "subscribing client");
                 let writer = Arc::into_inner(socket_path).unwrap();
-                let subscribers = self.subscribers.clone();
+                let subscribers = if v2 {
+                    self.subscribers_v2.clone()
+                } else {
+                    self.subscribers.clone()
+                };
 
                 let devices = self.device_info.clone();
                 let nodes = self.node_info.clone();
@@ -499,7 +524,13 @@ impl Model {
                                 .into_iter()
                                 .map(|(id, mute)| Event::NodeMute(id, mute)),
                         )
-                        .filter_map(|event| ron::ser::to_string(&event).ok());
+                        .filter_map(move |event| {
+                            if v2 {
+                                ron::ser::to_string(&event).ok()
+                            } else {
+                                ron::ser::to_string(&EventV1::from(event)).ok()
+                            }
+                        });
 
                     for event in current_events {
                         if writer.send(event.as_bytes()).await.is_err() {
@@ -1159,6 +1190,8 @@ pub enum Message {
     Server(Arc<Vec<pipewire::Event>>),
     /// Pipe for notifying clients about audio events.
     Subscribe(Arc<pipe::Sender>),
+    /// Pipe for notifying clients about v2 audio events.
+    SubscribeV2(Arc<pipe::Sender>),
     /// On init of the subscription, channels for closing background threads are given to the app.
     Init(Arc<pipewire::Sender>),
 }

--- a/audio-server/src/server.rs
+++ b/audio-server/src/server.rs
@@ -20,6 +20,15 @@ impl Server {
 
     /// Request a non-blocking anonymous pipe for receiving audio events from the server.
     pub async fn recv_events(&mut self) -> Result<OwnedFd, Error> {
+        self.subscribe(false).await
+    }
+
+    /// Request a non-blocking anonymous pipe for receiving v2 audio events from the server.
+    pub async fn recv_events_v2(&mut self) -> Result<OwnedFd, Error> {
+        self.subscribe(true).await
+    }
+
+    async fn subscribe(&mut self, v2: bool) -> Result<OwnedFd, Error> {
         // Create an anonymous block
         let (writer, reader) = tokio::net::unix::pipe::pipe().map_err(|why| Error::IO {
             code: why.raw_os_error(),
@@ -31,12 +40,13 @@ impl Server {
             why: format!("{}", why),
         })?;
 
-        if self
-            .backend
-            .sender
-            .send(crate::backend::Message::Subscribe(Arc::new(writer)))
-            .is_err()
-        {
+        let message = if v2 {
+            crate::backend::Message::SubscribeV2(Arc::new(writer))
+        } else {
+            crate::backend::Message::Subscribe(Arc::new(writer))
+        };
+
+        if self.backend.sender.send(message).is_err() {
             return Err(Error::ChannelSend);
         }
 

--- a/varlink-server/src/lib.rs
+++ b/varlink-server/src/lib.rs
@@ -72,6 +72,25 @@ where
 
     #[zlink(
         interface = "com.system76.CosmicSettings.Audio",
+        rename = "RecvEventsV2",
+        return_fds
+    )]
+    pub async fn audio_recv_events_v2(&mut self) -> (Result<(), audio::Error>, Vec<OwnedFd>) {
+        let mut fds = Vec::new();
+        let mut this = self.0.lock().await;
+        let reply = match this.audio_server.recv_events_v2().await {
+            Ok(fd) => {
+                fds.push(fd);
+                Ok(())
+            }
+            Err(why) => Err(why),
+        };
+
+        (reply, fds)
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Audio",
         rename = "DefaultSink"
     )]
     pub async fn audio_default_sink(&mut self) -> Result<audio::Node, audio::Error> {


### PR DESCRIPTION
This PR makes audio events backward compatible by switching to serde's adjacently tagged enum representation:

```rust
#[serde(tag = "t", content = "v")]
pub enum Event {
    ...
}
```

This gives events a consistent serialization format, allowing clients to safely handle unknown event variants without failing deserialization.

The existing event format is kept as `EventV1` for compatibility, while the new `Event` type uses the backward compatible representation.

---
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

