### PR TITLE
Fix low battery alert on systems without batteries

### DIFF
--- a/src/battery.rs
+++ b/src/battery.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio_stream::StreamExt;
-use upower_dbus::{BatteryLevel, UPowerProxy};
+use upower_dbus::{BatteryLevel, BatteryType, UPowerProxy};
 
 pub type OnBatteryFn = Box<dyn Fn(bool) -> Pin<Box<dyn Future<Output = bool>>>>;
 
@@ -101,6 +101,9 @@ pub async fn low_power_monitor() {
     let Ok(device) = upower.get_display_device().await else {
         return;
     };
+    if !matches!(device.type_().await, Ok(BatteryType::Battery)) {
+        return;
+    }
 
     let mut current_battery = BatteryLevel::Full;
     let mut last_critical_notification = Instant::now();


### PR DESCRIPTION
UPower may expose a DisplayDevice with Type=Unknown and Percentage=0
on systems without a battery.

cosmic-settings-daemon currently reacts to the DisplayDevice percentage
without checking whether the device is actually a battery. On a
batteryless Intel Hades Canyon NUC, this causes the daemon to enter
critical battery handling and repeatedly play the battery-low sound.

This change ignores the DisplayDevice unless its type is Battery.

Tested on Pop!_OS 24.04 with:
- UPower DisplayDevice Type=Unknown
- Percentage=0
- WarningLevel=None

With the patch applied, the repeating low-battery alert no longer occurs.

Closes #185