### PR TITLE
feat(printers): expose printers-server API over Varlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,26 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.3",
+ "shlex 1.3.0",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -1035,11 +1055,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmic-settings-printers-core"
+version = "0.1.0"
+source = "git+https://github.com/Abd002/cosmic-printers.git#8ddb9f4dd59bf125710db98d75247caf652a397e"
+dependencies = [
+ "nix",
+ "serde",
+ "zlink",
+]
+
+[[package]]
+name = "cosmic-settings-printers-server"
+version = "0.1.0"
+source = "git+https://github.com/Abd002/cosmic-printers.git#8ddb9f4dd59bf125710db98d75247caf652a397e"
+dependencies = [
+ "cosmic-settings-printers-core",
+ "cups_rs",
+ "futures-util",
+ "nix",
+ "percent-encoding",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "zlink",
+]
+
+[[package]]
 name = "cosmic-settings-varlink-server"
 version = "1.0.0"
 dependencies = [
  "cosmic-settings-audio-core",
  "cosmic-settings-audio-server",
+ "cosmic-settings-printers-core",
+ "cosmic-settings-printers-server",
  "dirs",
  "futures-util",
  "serde",
@@ -1182,6 +1232,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
 dependencies = [
  "dtor",
+]
+
+[[package]]
+name = "cups_rs"
+version = "0.3.0"
+source = "git+https://github.com/Abd002/cups-rs.git?branch=cups3-pr6-signatures#244356f1952ba36d8a13e6911848f7978243b5d6"
+dependencies = [
+ "bindgen 0.71.1",
+ "chrono",
+ "libc",
+ "pkg-config",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3152,7 +3214,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ad52764fca54818486f3cf75afec844d1f1a1568c24dcee25d41b1ab007dda"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "cc",
  "system-deps",
 ]
@@ -3545,6 +3607,19 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -4032,7 +4107,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2089f245b548723e60325773c27f586b7a2372c79ea941b246cd0d654706adc"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "libspa-sys",
  "system-deps",
 ]
@@ -4126,6 +4201,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/varlink-server/Cargo.toml
+++ b/varlink-server/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 [dependencies]
 cosmic-settings-audio-core = { path = "../audio-core"}
 cosmic-settings-audio-server = { path = "../audio-server" }
+cosmic-settings-printers-core = { git = "https://github.com/Abd002/cosmic-printers.git" }
+cosmic-settings-printers-server = { git = "https://github.com/Abd002/cosmic-printers.git" }
 dirs = "6.0.0"
 futures-util = "0.3.32"
 serde = "1.0.228"

--- a/varlink-server/src/lib.rs
+++ b/varlink-server/src/lib.rs
@@ -10,9 +10,10 @@
 
 use cosmic_settings_audio_core as audio;
 use cosmic_settings_audio_server as audio_server;
-use std::os::fd::OwnedFd;
-use std::path::PathBuf;
-use std::sync::Arc;
+use cosmic_settings_printers_core as printers;
+use cosmic_settings_printers_server as printers_server;
+use futures_util::{Stream, StreamExt};
+use std::{os::fd::OwnedFd, path::PathBuf, sync::Arc};
 use tokio::sync::Mutex;
 
 pub async fn init() -> (Daemon, impl Future<Output = ()> + 'static + Send) {
@@ -20,6 +21,7 @@ pub async fn init() -> (Daemon, impl Future<Output = ()> + 'static + Send) {
 
     let daemon = Daemon(Arc::new(Mutex::new(DaemonInner {
         audio_server: audio_server::Server::new(audio_ctx.clone()).await,
+        printers_server: printers_server::Server::new(),
     })));
 
     (daemon, audio_ctx.run(audio_ctx_rx))
@@ -341,8 +343,431 @@ where
             .set_playback_sink(playback_id, sink_id)
             .await
     }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "ListPrinters"
+    )]
+    pub async fn printers_list_printers(
+        &mut self,
+    ) -> Result<printers::ListPrintersReply, printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .list_printers()
+            .await
+            .map(|printers| printers::ListPrintersReply { printers })
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "GetPrinter"
+    )]
+    pub async fn printers_get_printer(
+        &mut self,
+        printer_id: String,
+    ) -> Result<printers::PrinterEntry, printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .get_printer(&printer_id)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "RefreshAvailableDestinations"
+    )]
+    pub async fn printers_refresh_available_destinations(&mut self) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .refresh_available_destinations()
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "StartPrinterApplicationDiscovery"
+    )]
+    pub async fn printers_start_printer_application_discovery(
+        &mut self,
+    ) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .start_printer_application_discovery()
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "StartAddPrinterDiscovery"
+    )]
+    pub async fn printers_start_add_printer_discovery(
+        &mut self,
+    ) -> Result<printers::StartAddPrinterDiscoveryReply, printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .start_add_printer_discovery()
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "GetAddPrinterDiscovery"
+    )]
+    pub async fn printers_get_add_printer_discovery(
+        &mut self,
+    ) -> Result<printers::AddPrinterDiscoveryReply, printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .get_add_printer_discovery()
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "ConfigureDiscoveredPrinter"
+    )]
+    pub async fn printers_configure_discovered_printer(
+        &mut self,
+        request: printers::ConfigureDiscoveredPrinterRequest,
+    ) -> Result<printers::ConfigurePrinterReply, printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .configure_discovered_printer(request)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "GetPrinterConfiguration"
+    )]
+    pub async fn printers_get_printer_configuration(
+        &mut self,
+        operation_id: String,
+    ) -> Result<printers::ConfigurePrinterReply, printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .get_printer_configuration(&operation_id)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "ListManualSetupPrinterApplications"
+    )]
+    pub async fn printers_list_manual_setup_printer_applications(
+        &mut self,
+    ) -> Result<printers::ListManualSetupApplicationsReply, printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .list_manual_setup_printer_applications()
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "ListPrinterApplications"
+    )]
+    pub async fn printers_list_printer_applications(
+        &mut self,
+    ) -> Result<printers::ListPrinterApplicationsReply, printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .list_printer_applications()
+            .await
+            .map(
+                |printer_applications| printers::ListPrinterApplicationsReply {
+                    printer_applications,
+                },
+            )
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "WatchPrinters",
+        more
+    )]
+    pub async fn printers_watch_printers(
+        &mut self,
+        _more: bool,
+    ) -> impl Stream<Item = zlink::Reply<printers::PrintersEvent>> + Unpin {
+        // Varlink continuation framing belongs at this transport boundary.
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .watch_printers()
+            .map(|event| zlink::Reply::new(Some(event)).set_continues(Some(true)))
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "DeletePrinter"
+    )]
+    pub async fn printers_delete_printer(
+        &mut self,
+        printer_id: String,
+    ) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .delete_printer(&printer_id)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "SetPrinterAcceptJobs"
+    )]
+    pub async fn printers_set_printer_accept_jobs(
+        &mut self,
+        printer_id: String,
+        enabled: bool,
+        reason: String,
+    ) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .set_printer_accept_jobs(&printer_id, enabled, &reason)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "SetPrinterDefault"
+    )]
+    pub async fn printers_set_printer_default(
+        &mut self,
+        printer_id: String,
+    ) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .set_printer_default(&printer_id)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "ClearPrinterDefault"
+    )]
+    pub async fn printers_clear_printer_default(&mut self) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .clear_printer_default()
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "SetPrinterOptionDefault"
+    )]
+    pub async fn printers_set_printer_option_default(
+        &mut self,
+        printer_id: String,
+        option: String,
+        values: Vec<String>,
+    ) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .set_printer_option_default(&printer_id, &option, &values)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "SetPrinterEnabled"
+    )]
+    pub async fn printers_set_printer_enabled(
+        &mut self,
+        printer_id: String,
+        enabled: bool,
+    ) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .set_printer_enabled(&printer_id, enabled)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "SetPrinterInfo"
+    )]
+    pub async fn printers_set_printer_info(
+        &mut self,
+        printer_id: String,
+        info: String,
+    ) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .set_printer_info(&printer_id, &info)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "SetPrinterLocation"
+    )]
+    pub async fn printers_set_printer_location(
+        &mut self,
+        printer_id: String,
+        location: String,
+    ) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .set_printer_location(&printer_id, &location)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "PrintTestPage"
+    )]
+    pub async fn printers_print_test_page(
+        &mut self,
+        printer_id: String,
+    ) -> Result<printers::PrintTestPageReply, printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .print_test_page(&printer_id)
+            .await
+            .map(|job_id| printers::PrintTestPageReply { job_id })
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "GetPrinterSupplies"
+    )]
+    pub async fn printers_get_printer_supplies(
+        &mut self,
+        printer_id: String,
+    ) -> Result<printers::GetPrinterSuppliesReply, printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .printer_supplies(&printer_id)
+            .await
+            .map(|supplies| printers::GetPrinterSuppliesReply { supplies })
+    }
+
+    #[zlink(interface = "com.system76.CosmicSettings.Printers", rename = "GetJobs")]
+    pub async fn printers_get_jobs(
+        &mut self,
+        printer_id: String,
+        filter: String,
+    ) -> Result<printers::GetJobsReply, printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .get_jobs(&printer_id, &filter)
+            .await
+            .map(|jobs| printers::GetJobsReply { jobs })
+    }
+
+    #[zlink(interface = "com.system76.CosmicSettings.Printers", rename = "MoveJob")]
+    pub async fn printers_move_job(
+        &mut self,
+        source_printer_id: String,
+        job_id: i32,
+        destination_printer_id: String,
+    ) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .move_job(&source_printer_id, job_id, &destination_printer_id)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "PauseJob"
+    )]
+    pub async fn printers_pause_job(
+        &mut self,
+        printer_id: String,
+        job_id: i32,
+    ) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .pause_job(&printer_id, job_id)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "ResumeJob"
+    )]
+    pub async fn printers_resume_job(
+        &mut self,
+        printer_id: String,
+        job_id: i32,
+    ) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .resume_job(&printer_id, job_id)
+            .await
+    }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Printers",
+        rename = "CancelJob"
+    )]
+    pub async fn printers_cancel_job(
+        &mut self,
+        printer_id: String,
+        job_id: i32,
+    ) -> Result<(), printers::Error> {
+        self.0
+            .lock()
+            .await
+            .printers_server
+            .cancel_job(&printer_id, job_id)
+            .await
+    }
 }
 
 pub struct DaemonInner {
     pub audio_server: audio_server::Server,
+    pub printers_server: printers_server::Server,
 }


### PR DESCRIPTION
## PR Description

This PR adds the `com.system76.CosmicSettings.Printers` Varlink interface to `cosmic-settings-daemon`.

The interface exposes printer management functionality from [`cosmic-printers`](https://github.com/Abd002/cosmic-printers) to COSMIC Settings, including printer discovery, configuration, print jobs, and live printer updates.


### Related work

- COSMIC Settings Printers page: https://github.com/pop-os/cosmic-settings/pull/2182
- [`cosmic-printers`](https://github.com/Abd002/cosmic-printers): shared printer backend and types.
### How to test

Prerequisites: A Linux system with [CUPS](https://github.com/OpenPrinting/cups) installed and running, and the [CUPS 3 client library (`libcups3`)](https://github.com/OpenPrinting/libcups) with its development files.

Start the daemon:

```sh
cargo run
```

---
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.