### PR TITLE
feat: add recording stream support

### DIFF
--- a/audio-client/src/lib.rs
+++ b/audio-client/src/lib.rs
@@ -152,4 +152,11 @@ pub trait CosmicAudioProxy {
         playback_id: u32,
         sink_id: u32,
     ) -> zlink::Result<Result<(), Error>>;
+
+    /// Move a recording stream to an audio source.
+    async fn set_playback_source(
+        &mut self,
+        recording_id: u32,
+        source_id: u32,
+    ) -> zlink::Result<Result<(), Error>>;
 }

--- a/audio-client/src/lib.rs
+++ b/audio-client/src/lib.rs
@@ -154,7 +154,7 @@ pub trait CosmicAudioProxy {
     ) -> zlink::Result<Result<(), Error>>;
 
     /// Move a recording stream to an audio source.
-    async fn set_playback_source(
+    async fn set_recording_source(
         &mut self,
         recording_id: u32,
         source_id: u32,

--- a/audio-core/src/lib.rs
+++ b/audio-core/src/lib.rs
@@ -13,6 +13,8 @@ pub enum Error {
     NoActiveSource,
     InvalidPlayback,
     InvalidSink,
+    InvalidRecording,
+    InvalidSource,
 }
 
 impl std::fmt::Display for Error {
@@ -24,6 +26,8 @@ impl std::fmt::Display for Error {
             Error::NoActiveSource => f.write_str("no active source to apply operation to"),
             Error::InvalidPlayback => f.write_str("node is not an audio playback stream"),
             Error::InvalidSink => f.write_str("node is not an audio sink"),
+            Error::InvalidRecording => f.write_str("node is not an audio recording stream"),
+            Error::InvalidSource => f.write_str("node is not an audio source"),
         }
     }
 }
@@ -110,6 +114,10 @@ pub enum Event {
     Playback(u32, PlaybackInfo),
     /// The sink explicitly targeted by a playback stream, or `None` to follow the default sink.
     PlaybackTarget(u32, Option<u32>),
+    /// Add an audio recording stream.
+    Recording(u32, RecordingInfo),
+    /// The source that a recording stream is capturing from, if any
+    RecordingTarget(u32, Option<u32>),
     /// Mute status of a node changed.
     NodeMute(u32, bool),
     /// Volume of a node changed.
@@ -167,6 +175,7 @@ impl From<Event> for EventV1 {
             Event::MonoAudio(enabled) => Self::MonoAudio(enabled),
             Event::Node(id, info) => Self::Node(id, info),
             Event::Playback(..) | Event::PlaybackTarget(..) => Self::Unknown,
+            Event::Recording(..) | Event::RecordingTarget(..) => Self::Unknown,
             Event::NodeMute(id, mute) => Self::NodeMute(id, mute),
             Event::NodeVolume(id, volume, balance) => Self::NodeVolume(id, volume, balance),
             Event::Profile(id, index, info) => Self::Profile(id, index, info),
@@ -234,6 +243,25 @@ pub struct PlaybackInfo {
     pub icon_name: Option<String>,
     pub media_name: Option<String>,
     pub node_name: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RecordingInfo {
+    pub application_id: Option<String>,
+    pub application_name: Option<String>,
+    pub icon_name: Option<String>,
+    pub media_name: Option<String>,
+    pub node_name: String,
+    pub state: StreamState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+pub enum StreamState {
+    Idle,
+    Running,
+    Creating,
+    Suspended,
+    Error,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/audio-server/src/backend.rs
+++ b/audio-server/src/backend.rs
@@ -74,6 +74,8 @@ pub struct Model {
     pub sink_node_serials: IntMap<NodeId, u64>,
     /// Node IDs for sources
     source_node_ids: Vec<NodeId>,
+    /// PipeWire object serials for source nodes.
+    pub source_node_serials: IntMap<NodeId, u64>,
 
     /** Playback stream information */
 
@@ -83,6 +85,12 @@ pub struct Model {
     playback_targets: IntMap<NodeId, String>,
     /// Resolved sink node IDs for playback streams with explicit targets.
     playback_sink_ids: IntMap<NodeId, NodeId>,
+    /// Recording stream information shared with subscribed varlink clients.
+    pub recording_info: IntMap<NodeId, cosmic_settings_audio_core::RecordingInfo>,
+    /// Raw PipeWire `target.object` values for recording streams.
+    recording_targets: IntMap<NodeId, String>,
+    /// Resolved source node IDs for recording streams with explicit targets.
+    recording_source_ids: IntMap<NodeId, NodeId>,
 
     /** Device object information */
 
@@ -189,9 +197,13 @@ impl Model {
             sink_node_ids: Default::default(),
             sink_node_serials: Default::default(),
             source_node_ids: Default::default(),
+            source_node_serials: Default::default(),
             playback_info: Default::default(),
             playback_targets: Default::default(),
             playback_sink_ids: Default::default(),
+            recording_info: Default::default(),
+            recording_targets: Default::default(),
+            recording_source_ids: Default::default(),
             device_info: Default::default(),
             device_profiles: Default::default(),
             active_profiles: Default::default(),
@@ -474,6 +486,8 @@ impl Model {
                 let nodes = self.node_info.clone();
                 let playback = self.playback_info.clone();
                 let playback_sinks = self.playback_sink_ids.clone();
+                let recording = self.recording_info.clone();
+                let recording_sources = self.recording_source_ids.clone();
                 let profiles = self.device_profiles.clone();
                 let routes = self.device_routes.clone();
                 let active_profiles = self.active_profiles.clone();
@@ -537,6 +551,18 @@ impl Model {
                         .chain(playback_sinks.into_iter().map(|(playback_id, sink_id)| {
                             Event::PlaybackTarget(playback_id, Some(sink_id))
                         }))
+                        .chain(
+                            recording
+                                .into_iter()
+                                .map(|(node_id, info)| Event::Recording(node_id, info)),
+                        )
+                        .chain(
+                            recording_sources
+                                .into_iter()
+                                .map(|(recording_id, source_id)| {
+                                    Event::RecordingTarget(recording_id, Some(source_id))
+                                }),
+                        )
                         .chain(default_sink.into_iter().map(Event::DefaultSink))
                         .chain(default_source.into_iter().map(Event::DefaultSource))
                         .chain(
@@ -1010,6 +1036,13 @@ impl Model {
 
                     pipewire::MediaClass::Source => {
                         self.source_node_ids.push(node.object_id);
+                        self.source_node_serials
+                            .insert(node.object_id, node.object_serial);
+
+                        let recording_ids = self.recording_targets.keys().collect::<Vec<_>>();
+                        for recording_id in recording_ids {
+                            self.refresh_recording_target(recording_id, false).await;
+                        }
 
                         // Set the source as the default if it matches the server.
                         if self.active_source_node_name == node.node_name {
@@ -1029,7 +1062,7 @@ impl Model {
                     }
 
                     pipewire::MediaClass::Playback => {
-                        let Some(playback) = node.playback else {
+                        let Some(playback) = node.stream else {
                             tracing::warn!(
                                 target: "audio-backend",
                                 node_id = node.object_id,
@@ -1049,6 +1082,31 @@ impl Model {
                         self.playback_info.insert(node.object_id, info.clone());
                         self.emit_event(Event::Playback(node.object_id, info)).await;
                         self.refresh_playback_target(node.object_id, true).await;
+                    }
+
+                    pipewire::MediaClass::Record => {
+                        let Some(record) = node.stream else {
+                            tracing::warn!(
+                                target: "audio-backend",
+                                node_id = node.object_id,
+                                "recording node missing stream metadata"
+                            );
+                            return;
+                        };
+
+                        let info = cosmic_settings_audio_core::RecordingInfo {
+                            application_id: record.application_id,
+                            application_name: record.application_name,
+                            icon_name: record.icon_name,
+                            media_name: record.media_name,
+                            node_name: node.node_name,
+                            state: stream_state(&node.state),
+                        };
+
+                        self.recording_info.insert(node.object_id, info.clone());
+                        self.emit_event(Event::Recording(node.object_id, info))
+                            .await;
+                        self.refresh_recording_target(node.object_id, true).await;
                     }
                 }
 
@@ -1082,16 +1140,28 @@ impl Model {
                 });
             }
 
-            pipewire::Event::PlaybackTarget(id, target) => {
-                match target {
-                    Some(target) => {
-                        self.playback_targets.insert(id, target);
+            pipewire::Event::StreamTarget(id, target) => {
+                if self.recording_info.contains_key(id) {
+                    match target {
+                        Some(target) => {
+                            self.recording_targets.insert(id, target);
+                        }
+                        None => {
+                            self.recording_targets.remove(id);
+                        }
                     }
-                    None => {
-                        self.playback_targets.remove(id);
+                    self.refresh_recording_target(id, true).await;
+                } else {
+                    match target {
+                        Some(target) => {
+                            self.playback_targets.insert(id, target);
+                        }
+                        None => {
+                            self.playback_targets.remove(id);
+                        }
                     }
+                    self.refresh_playback_target(id, true).await;
                 }
-                self.refresh_playback_target(id, true).await;
             }
 
             pipewire::Event::DefaultSink(node_name) => {
@@ -1123,6 +1193,11 @@ impl Model {
                 } else {
                     tracing::warn!(target: "audio-backend", node_name = self.active_source_node_name, "default source node ID not found");
                     self.active_source_not_found = true;
+                }
+
+                let recording_ids = self.recording_info.keys().collect::<Vec<_>>();
+                for recording_id in recording_ids {
+                    self.refresh_recording_target(recording_id, false).await;
                 }
             }
 
@@ -1174,6 +1249,48 @@ impl Model {
         }
     }
 
+    async fn refresh_recording_target(&mut self, recording_id: NodeId, force: bool) {
+        if !self.recording_info.contains_key(recording_id) {
+            return;
+        }
+
+        let source_id = self
+            .recording_targets
+            .get(recording_id)
+            .and_then(|target| {
+                if let Ok(serial) = target.parse::<u64>() {
+                    self.source_node_serials
+                        .iter()
+                        .find_map(|(id, value)| (*value == serial).then_some(id))
+                        .or_else(|| {
+                            self.sink_node_serials
+                                .iter()
+                                .find_map(|(id, value)| (*value == serial).then_some(id))
+                        })
+                } else {
+                    self.node_info.iter().find_map(|(id, node)| {
+                        (!node.is_sink && node.name == *target).then_some(id)
+                    })
+                }
+            })
+            .or(self.active_source_node);
+        let previous = self.recording_source_ids.get(recording_id).copied();
+
+        match source_id {
+            Some(source_id) => {
+                self.recording_source_ids.insert(recording_id, source_id);
+            }
+            None => {
+                self.recording_source_ids.remove(recording_id);
+            }
+        }
+
+        if force || previous != source_id {
+            self.emit_event(Event::RecordingTarget(recording_id, source_id))
+                .await;
+        }
+    }
+
     async fn remove_device(&mut self, id: DeviceId) {
         tracing::debug!(target: "audio-backend", "Device {id} removed");
         _ = self.device_headset_check.remove(id);
@@ -1211,6 +1328,10 @@ impl Model {
         _ = self.playback_targets.remove(id);
         _ = self.playback_sink_ids.remove(id);
         _ = self.sink_node_serials.remove(id);
+        _ = self.recording_info.remove(id);
+        _ = self.recording_targets.remove(id);
+        _ = self.recording_source_ids.remove(id);
+        _ = self.source_node_serials.remove(id);
 
         let affected_playback = self
             .playback_sink_ids
@@ -1219,6 +1340,15 @@ impl Model {
             .collect::<Vec<_>>();
         for playback_id in affected_playback {
             self.refresh_playback_target(playback_id, false).await;
+        }
+
+        let affected_recordings = self
+            .recording_source_ids
+            .iter()
+            .filter_map(|(recording_id, source_id)| (*source_id == id).then_some(recording_id))
+            .collect::<Vec<_>>();
+        for recording_id in affected_recordings {
+            self.refresh_recording_target(recording_id, false).await;
         }
         _ = self.node_devices.remove(id);
         _ = self.node_mute.remove(id);
@@ -1344,6 +1474,17 @@ pub async fn pactl_set_default_source(node_name: &str) {
         .stderr(Stdio::null())
         .status()
         .await;
+}
+
+/// Convert a PipeWire node state to its audio-core equivalent.
+fn stream_state(state: &pipewire::node::State) -> cosmic_settings_audio_core::StreamState {
+    match state {
+        pipewire::node::State::Idle => cosmic_settings_audio_core::StreamState::Idle,
+        pipewire::node::State::Running => cosmic_settings_audio_core::StreamState::Running,
+        pipewire::node::State::Creating => cosmic_settings_audio_core::StreamState::Creating,
+        pipewire::node::State::Suspended => cosmic_settings_audio_core::StreamState::Suspended,
+        pipewire::node::State::Error(_) => cosmic_settings_audio_core::StreamState::Error,
+    }
 }
 
 pub fn pipewire_profile_to_cosmic(

--- a/audio-server/src/server.rs
+++ b/audio-server/src/server.rs
@@ -299,7 +299,7 @@ impl Server {
     }
 
     /// Move a recording stream to a source using WirePlumber's linking metadata.
-    pub async fn set_playback_source(
+    pub async fn set_recording_source(
         &mut self,
         recording_id: u32,
         source_id: u32,

--- a/audio-server/src/server.rs
+++ b/audio-server/src/server.rs
@@ -297,6 +297,31 @@ impl Server {
         });
         Ok(())
     }
+
+    /// Move a recording stream to a source using WirePlumber's linking metadata.
+    pub async fn set_playback_source(
+        &mut self,
+        recording_id: u32,
+        source_id: u32,
+    ) -> Result<(), Error> {
+        let model = self.backend.model.lock().await;
+        if !model.recording_info.contains_key(recording_id) {
+            return Err(Error::InvalidRecording);
+        }
+        let source_serial = model
+            .source_node_serials
+            .get(source_id)
+            .ok_or(Error::InvalidSource)?;
+
+        model.pipewire_send(cosmic_pipewire::Request::SetMetadataProperty {
+            name: "default".to_owned(),
+            subject: recording_id,
+            key: "target.object".to_owned(),
+            type_: Some("Spa:Id".to_owned()),
+            value: Some(source_serial.to_string()),
+        });
+        Ok(())
+    }
 }
 
 fn set_node_mute(

--- a/cosmic-pipewire/src/lib.rs
+++ b/cosmic-pipewire/src/lib.rs
@@ -8,7 +8,8 @@ pub use device::Device;
 
 pub mod node;
 use intmap::IntMap;
-pub use node::{MediaClass, Node, NodeProps, PlaybackInfo};
+pub use node::{MediaClass, Node, NodeProps, StreamInfo};
+use std::collections::HashMap;
 
 mod profile;
 pub use profile::{Profile, ProfileClass};
@@ -84,6 +85,7 @@ fn run_service(
         default_sink_name: String::new(),
         default_source_name: String::new(),
         nodes: IntMap::new(),
+        node_info_props: IntMap::new(),
         active_routes: IntMap::new(),
         routes: IntMap::new(),
         node_devices: IntMap::new(),
@@ -315,10 +317,27 @@ where
         .info({
             let state = Rc::downgrade(&state);
             move |info| {
-                if let Some(node) = Node::from_node(info)
-                    && let Some(state) = state.upgrade()
-                {
-                    state.borrow_mut().add_node(id, node);
+                let Some(state) = state.upgrade() else {
+                    return;
+                };
+                let mut state = state.borrow_mut();
+
+                // Merge the update props into the accumulated props for this node.
+                if let Some(props) = info.props() {
+                    let entry = state.node_info_props.entry(id).or_default();
+                    for (key, value) in props.iter() {
+                        entry.insert(key.to_owned(), value.to_owned());
+                    }
+                }
+
+                let Some(props) = state.node_info_props.get(id) else {
+                    return;
+                };
+                if let Some(node) = Node::from_props(
+                    props.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+                    info.state(),
+                ) {
+                    state.add_node(id, node);
                 }
             }
         })
@@ -427,7 +446,7 @@ where
                             if let Some(state) = state.upgrade() {
                                 state
                                     .borrow_mut()
-                                    .playback_target(subject, value.map(ToOwned::to_owned));
+                                    .stream_target(subject, value.map(ToOwned::to_owned));
                             }
                         }
 
@@ -508,8 +527,8 @@ pub enum Event {
     DefaultSource(String),
     /// Mono audio node setting changed.
     MonoAudio(bool),
-    /// A playback stream's explicit target object changed.
-    PlaybackTarget(NodeId, Option<String>),
+    /// A stream explicit target object changed.
+    StreamTarget(NodeId, Option<String>),
     /// Emitted when the properties of a node has changed.
     NodeProperties(NodeId, NodeProps),
     /// A device with the given device_id was removed.
@@ -599,6 +618,9 @@ struct State {
     default_sink_name: String,
     /// Associates the pipewire ID of a node to its node and device IDs.
     nodes: IntMap<PipewireId, (NodeId, Option<DeviceId>)>,
+    /// Info updates carry only changed props, they must be merged with
+    /// previously-seen values before parsing a node.
+    node_info_props: IntMap<PipewireId, HashMap<String, String>>,
     /// Routes which are currently in use by devices.
     active_routes: IntMap<DeviceId, Vec<Route>>,
     /// Routes which are supported by devices.
@@ -735,8 +757,8 @@ impl State {
         self.on_event(Event::MonoAudio(enabled))
     }
 
-    fn playback_target(&mut self, id: NodeId, target: Option<String>) {
-        self.on_event(Event::PlaybackTarget(id, target))
+    fn stream_target(&mut self, id: NodeId, target: Option<String>) {
+        self.on_event(Event::StreamTarget(id, target))
     }
 
     fn on_event(&mut self, event: Event) {
@@ -763,6 +785,7 @@ impl State {
     }
 
     fn remove_node(&mut self, id: PipewireId) {
+        self.node_info_props.remove(id);
         if let Some((node_id, _)) = self.nodes.remove(id) {
             self.node_card_profile_device.remove(node_id);
             self.node_devices.remove(node_id);

--- a/cosmic-pipewire/src/node.rs
+++ b/cosmic-pipewire/src/node.rs
@@ -25,12 +25,12 @@ pub struct Node {
     pub icon_name: String,
     pub media_class: MediaClass,
     pub node_name: String,
-    pub playback: Option<PlaybackInfo>,
+    pub stream: Option<StreamInfo>,
     pub state: State,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PlaybackInfo {
+pub struct StreamInfo {
     pub application_id: Option<String>,
     pub application_name: Option<String>,
     pub icon_name: Option<String>,
@@ -46,19 +46,33 @@ pub enum State {
     Error(String),
 }
 
+impl From<NodeState<'_>> for State {
+    fn from(node_state: NodeState) -> Self {
+        match node_state {
+            NodeState::Idle => State::Idle,
+            NodeState::Running => State::Running,
+            NodeState::Creating => State::Creating,
+            NodeState::Suspended => State::Suspended,
+            NodeState::Error(why) => State::Error(why.to_owned()),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MediaClass {
     Source,
     Sink,
     Playback,
+    Record,
 }
 
 impl Node {
-    /// Attains process info from a pipewire info node.
+    /// Attains node info from a props iterator and a node state.
     #[must_use]
-    pub fn from_node(info: &NodeInfoRef) -> Option<Self> {
-        let props = info.props()?;
-
+    pub fn from_props<'a>(
+        props: impl Iterator<Item = (&'a str, &'a str)>,
+        node_state: NodeState,
+    ) -> Option<Self> {
         let mut audio_channels = 1;
         let mut audio_position = String::new();
         let mut application_id = None;
@@ -76,7 +90,7 @@ impl Node {
         let mut object_id = None;
         let mut object_serial = None;
 
-        for (entry, value) in props.iter() {
+        for (entry, value) in props {
             match entry {
                 "device.id" => device_id = value.parse::<u32>().ok(),
                 "object.id" => object_id = Some(value.parse::<u32>().ok()?),
@@ -110,6 +124,7 @@ impl Node {
                         "Audio/Sink" => MediaClass::Sink,
                         "Audio/Source" => MediaClass::Source,
                         "Stream/Output/Audio" => MediaClass::Playback,
+                        "Stream/Input/Audio" => MediaClass::Record,
                         _ => return None,
                     })
                 }
@@ -126,12 +141,14 @@ impl Node {
         }
 
         let media_class = media_class?;
-        let playback = matches!(media_class, MediaClass::Playback).then_some(PlaybackInfo {
-            application_id,
-            application_name,
-            icon_name: application_icon_name,
-            media_name,
-        });
+        let stream = matches!(media_class, MediaClass::Playback | MediaClass::Record).then_some(
+            StreamInfo {
+                application_id,
+                application_name,
+                icon_name: application_icon_name,
+                media_name,
+            },
+        );
 
         let device = Node {
             object_id: object_id?,
@@ -154,17 +171,17 @@ impl Node {
             audio_channels,
             audio_position,
             node_name,
-            playback,
-            state: match info.state() {
-                NodeState::Idle => State::Idle,
-                NodeState::Running => State::Running,
-                NodeState::Creating => State::Creating,
-                NodeState::Suspended => State::Suspended,
-                NodeState::Error(why) => State::Error(why.to_owned()),
-            },
+            stream,
+            state: node_state.into(),
         };
 
         Some(device)
+    }
+
+    #[must_use]
+    pub fn from_node(info: &NodeInfoRef) -> Option<Self> {
+        let props = info.props()?;
+        Self::from_props(props.iter(), info.state())
     }
 }
 

--- a/varlink-server/src/lib.rs
+++ b/varlink-server/src/lib.rs
@@ -344,9 +344,9 @@ where
 
     #[zlink(
         interface = "com.system76.CosmicSettings.Audio",
-        rename = "SetPlaybackSource"
+        rename = "SetRecordingSource"
     )]
-    pub async fn audio_set_playback_source(
+    pub async fn audio_set_recording_source(
         &mut self,
         recording_id: u32,
         source_id: u32,
@@ -355,7 +355,7 @@ where
             .lock()
             .await
             .audio_server
-            .set_playback_source(recording_id, source_id)
+            .set_recording_source(recording_id, source_id)
             .await
     }
 }

--- a/varlink-server/src/lib.rs
+++ b/varlink-server/src/lib.rs
@@ -341,6 +341,23 @@ where
             .set_playback_sink(playback_id, sink_id)
             .await
     }
+
+    #[zlink(
+        interface = "com.system76.CosmicSettings.Audio",
+        rename = "SetPlaybackSource"
+    )]
+    pub async fn audio_set_playback_source(
+        &mut self,
+        recording_id: u32,
+        source_id: u32,
+    ) -> Result<(), audio::Error> {
+        self.0
+            .lock()
+            .await
+            .audio_server
+            .set_playback_source(recording_id, source_id)
+            .await
+    }
 }
 
 pub struct DaemonInner {


### PR DESCRIPTION
This pull request adds support for recording stream source selection to the audio daemon. It introduces backend tracking for PipeWire recording streams and a varlink method to move a recording stream to a different audio source.

This is a base PR for two upcoming features: a microphone-in-use indicator for the COSMIC applet and the ability to change the audio source per app in the Settings app.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

